### PR TITLE
Update version to 0.7.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,128 @@
+before_script:
+- pip install tox setuptools
+
+flake8:
+  image: "python:2.7"
+  cache:
+    key: flake8
+    paths:
+    - .tox/flake8
+  script:
+  - tox -e flake8
+
+check_rst:
+  image: "python:2.7"
+  cache:
+    key: check_rst
+    paths:
+    - .tox/check_rst
+  script:
+  - tox -e check_rst
+
+py27-django17:
+  image: "python:2.7"
+  cache:
+    key: py27-django17
+    paths:
+    - .tox/py27-django17
+  script:
+  - tox -e py27-django17
+
+py27-django18:
+  image: "python:2.7"
+  cache:
+    key: py27-django18
+    paths:
+    - .tox/py27-django18
+  script:
+  - tox -e py27-django18
+
+py27-django19:
+  image: "python:2.7"
+  cache:
+    key: py27-django19
+    paths:
+    - .tox/py27-django19
+  script:
+  - tox -e py27-django19
+
+py27-django110:
+  image: "python:2.7"
+  cache:
+    key: py27-django110
+    paths:
+    - .tox/py27-django110
+  script:
+  - tox -e py27-django110
+
+py34-django17:
+  image: "python:3.4"
+  cache:
+    key: py34-django17
+    paths:
+    - .tox/py34-django17
+  script:
+  - tox -e py34-django17
+
+py34-django18:
+  image: "python:3.4"
+  cache:
+    key: py34-django18
+    paths:
+    - .tox/py34-django18
+  script:
+  - tox -e py34-django18
+
+py34-django19:
+  image: "python:3.4"
+  cache:
+    key: py34-django19
+    paths:
+    - .tox/py34-django19
+  script:
+  - tox -e py34-django19
+
+py34-django110:
+  image: "python:3.4"
+  cache:
+    key: py34-django110
+    paths:
+    - .tox/py34-django110
+  script:
+  - tox -e py34-django110
+
+py35-django18:
+  image: "python:3.5"
+  cache:
+    key: py35-django18
+    paths:
+    - .tox/py35-django18
+  script:
+  - tox -e py35-django18
+
+py35-django19:
+  image: "python:3.5"
+  cache:
+    key: py35-django19
+    paths:
+    - .tox/py35-django19
+  script:
+  - tox -e py35-django19
+
+py35-django110:
+  image: "python:3.5"
+  cache:
+    key: py35-django110
+    paths:
+    - .tox/py35-django110
+  script:
+  - tox -e py35-django110
+
+coverage:
+  image: "python:2.7"
+  cache:
+    key: coverage
+    paths:
+    - .tox/coverage
+  script:
+  - tox -e coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,22 @@ matrix:
     env: TOX_ENV=py27-django18
   - python: "2.7"
     env: TOX_ENV=py27-django19
+  - python: "2.7"
+    env: TOX_ENV=py27-django110
   - python: "3.4"
     env: TOX_ENV=py34-django17
   - python: "3.4"
     env: TOX_ENV=py34-django18
   - python: "3.4"
     env: TOX_ENV=py34-django19
+  - python: "3.4"
+    env: TOX_ENV=py34-django110
   - python: "3.5"
     env: TOX_ENV=py35-django18
   - python: "3.5"
     env: TOX_ENV=py35-django19
+  - python: "3.5"
+    env: TOX_ENV=py35-django110
   - python: "2.7"
     env: TOX_ENV=coverage
 cache:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 .. contents:: Table of Contents
    :depth: 2
 
+Unreleased
+==========
+
+Added
+-----
+* Add Django 1.10 support
+
+
 v0.7.1 - 2016-08-24
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 .. contents:: Table of Contents
    :depth: 2
 
-Unreleased
-==========
+v0.7.2 - 2016-08-31
+===================
 
 Added
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Unreleased
 Added
 -----
 * Add Django 1.10 support
+* Add support of gitlab continuous integration
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Added
 -----
 * Add Django 1.10 support
 
+Fixed
+-----
+* Fix BootsrapForm: placeholder on Input and Textarea only, use class form-control on
+  Input, Select and Textarea.
+
 
 v0.7.1 - 2016-08-24
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Fixed
 -----
 * Fix BootsrapForm: placeholder on Input and Textarea only, use class form-control on
   Input, Select and Textarea.
+* Fix lang attribute in django 1.7. On html pages, the lang attribute of the <html> was not
+  present in django 1.7. We use now a methode to display it that is also available in django 1.7
 
 
 v0.7.1 - 2016-08-24

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ dist:
 
 test_venv/bin/python:
 	virtualenv test_venv
-	test_venv/bin/pip install -U --requirement requirements-dev.txt 'Django<1.10'
+	test_venv/bin/pip install -U --requirement requirements-dev.txt 'Django<1.11'
 
 test_venv/cas/manage.py: test_venv
 	mkdir -p test_venv/cas

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Dependencies
 
 ``django-cas-server`` depends on the following python packages:
 
-* Django >= 1.7.1 < 1.10
+* Django >= 1.7.1 < 1.11
 * requests >= 2.4
 * requests_futures >= 0.9.5
 * lxml >= 3.4

--- a/cas_server/__init__.py
+++ b/cas_server/__init__.py
@@ -11,7 +11,7 @@
 """A django CAS server application"""
 
 #: version of the application
-VERSION = '0.7.1'
+VERSION = '0.7.2'
 
 #: path the the application configuration class
 default_app_config = 'cas_server.apps.CasAppConfig'

--- a/cas_server/forms.py
+++ b/cas_server/forms.py
@@ -12,6 +12,7 @@
 from .default_settings import settings
 
 from django import forms
+from django.forms import widgets
 from django.utils.translation import ugettext_lazy as _
 
 import cas_server.utils as utils
@@ -27,13 +28,13 @@ class BootsrapForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super(BootsrapForm, self).__init__(*args, **kwargs)
         for field in self.fields.values():
-            # Only tweak the fiel if it will be displayed
-            if not isinstance(field.widget, forms.HiddenInput):
+            # Only tweak the field if it will be displayed
+            if not isinstance(field.widget, widgets.HiddenInput):
                 attrs = {}
-                if not isinstance(field.widget, forms.CheckboxInput):
+                if isinstance(field.widget, (widgets.Input, widgets.Select, widgets.Textarea)):
                     attrs['class'] = "form-control"
-                    if field.label:  # pragma: no branch (currently all field are hidden or labeled)
-                        attrs["placeholder"] = field.label
+                if isinstance(field.widget, (widgets.Input, widgets.Textarea)) and field.label:
+                    attrs["placeholder"] = field.label
                 if field.required:
                     attrs["required"] = "required"
                 field.widget.attrs.update(attrs)

--- a/cas_server/templates/cas_server/base.html
+++ b/cas_server/templates/cas_server/base.html
@@ -1,5 +1,5 @@
-{% load i18n %}{% load staticfiles %}<!DOCTYPE html>
-<html{% if request.LANGUAGE_CODE %} lang="{{ request.LANGUAGE_CODE }}"{% endif %}>
+{% load i18n %}{% load staticfiles %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html{% if LANGUAGE_CODE %} lang="{{LANGUAGE_CODE}}"{% endif %}>
     <head>
         <meta charset="utf-8">
         <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge" /><![endif]-->

--- a/cas_server/tests/settings.py
+++ b/cas_server/tests/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
+import django
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -40,7 +41,7 @@ INSTALLED_APPS = [
     'cas_server',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -50,6 +51,8 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.locale.LocaleMiddleware',
 ]
+if django.VERSION < (1, 10):
+    MIDDLEWARE_CLASSES = MIDDLEWARE
 
 TEMPLATES = [
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django >= 1.7.1,<1.10
+Django >= 1.7.1,<1.11
 setuptools>=5.5
 requests>=2.4
 requests_futures>=0.9.5

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
             'Framework :: Django :: 1.7',
             'Framework :: Django :: 1.8',
             'Framework :: Django :: 1.9',
+            'Framework :: Django :: 1.10',
             'Intended Audience :: Developers',
             'Intended Audience :: System Administrators',
             'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
@@ -58,7 +59,7 @@ if __name__ == '__main__':
         },
         keywords=['django', 'cas', 'cas3', 'server', 'sso', 'single sign-on', 'authentication', 'auth'],
         install_requires=[
-            'Django >= 1.7,<1.10', 'requests >= 2.4', 'requests_futures >= 0.9.5',
+            'Django >= 1.7,<1.11', 'requests >= 2.4', 'requests_futures >= 0.9.5',
             'lxml >= 3.4', 'six >= 1'
         ],
         url="https://github.com/nitmir/django-cas-server",

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,14 @@ envlist=
     py27-django17,
     py27-django18,
     py27-django19,
+    py27-django110,
     py34-django17,
     py34-django18,
     py34-django19,
+    py34-django110,
     py35-django18,
     py35-django19,
+    py35-django110,
 
 [flake8]
 max-line-length=100
@@ -53,6 +56,12 @@ deps =
     Django>=1.9,<1.10
     {[base]deps}
 
+[testenv:py27-django110]
+basepython=python2.7
+deps =
+    Django>=1.10,<1.11
+    {[base]deps}
+
 [testenv:py34-django17]
 basepython=python3.4
 deps =
@@ -71,6 +80,12 @@ deps =
     Django>=1.9,<1.10
     {[base]deps}
 
+[testenv:py34-django110]
+basepython=python3.4
+deps =
+    Django>=1.10,<1.11
+    {[base]deps}
+
 [testenv:py35-django18]
 basepython=python3.5
 deps =
@@ -81,6 +96,12 @@ deps =
 basepython=python3.5
 deps =
     Django>=1.9,<1.10
+    {[base]deps}
+
+[testenv:py35-django110]
+basepython=python3.5
+deps =
+    Django>=1.10,<1.11
     {[base]deps}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -135,7 +135,7 @@ deps=
     codacy-coverage
 skip_install=True
 commands=
-    py.test --cov=cas_server --cov-report xml
+    py.test --cov=cas_server --cov-report xml --cov-report term
     python-codacy-coverage -r {toxinidir}/coverage.xml
     {[post_cmd]commands}
 whitelist_externals={[post_cmd]whitelist_externals}


### PR DESCRIPTION
Added
-----
* Add Django 1.10 support
* Add support of gitlab continuous integration

Fixed
-----
* Fix BootsrapForm: placeholder on Input and Textarea only, use class form-control on
  Input, Select and Textarea.
* Fix lang attribute in django 1.7. On html pages, the lang attribute of the <html> was not
  present in django 1.7. We use now a methode to display it that is also available in django 1.7
