### PR TITLE
RFC: Add CAS_DJANGO_AUTOLOGIN option

### DIFF
--- a/cas_server/default_settings.py
+++ b/cas_server/default_settings.py
@@ -47,6 +47,8 @@ CAS_REDIRECT_TO_LOGIN_AFTER_LOGOUT = False
 
 #: A dotted path to a class or a class implementing cas_server.auth.AuthUser.
 CAS_AUTH_CLASS = 'cas_server.auth.DjangoAuthUser'
+#: Whether to automatically authenticate an already logged in Django user.
+CAS_DJANGO_AUTOLOGIN = False
 #: Path to certificate authorities file. Usually on linux the local CAs are in
 #: /etc/ssl/certs/ca-certificates.crt. ``True`` tell requests to use its internal certificat
 #: authorities.


### PR DESCRIPTION
This allows to automatically authenticate a user that already has an active Django session, avoiding her to re-enter her credentials.

Disclaimer:
I know this is a pretty dump implementation, that's why it's just an RFC. It has been tested on my setup, with Django 1.11, with the default `CAS_AUTH_CLASS` (DjangoAuthUser).  
I made it by copy-pasting the interesting parts I found in the `post` handling, but I think there could be code refactoring here.   
What do you suggest, guy? I am in the right direction?