### PR TITLE
set ldap3 client_strategy from sync to sync-restartable

### DIFF
--- a/cas_server/auth.py
+++ b/cas_server/auth.py
@@ -277,6 +277,7 @@ class LdapAuthUser(DBAuthUser):  # pragma: no cover
                 settings.CAS_LDAP_SERVER,
                 settings.CAS_LDAP_USER,
                 settings.CAS_LDAP_PASSWORD,
+                client_strategy="RESTARTABLE",
                 auto_bind=True
             )
             cls._conn = conn


### PR DESCRIPTION
set ldap3 client_strategy from sync(default) to sync-restartable;
avoid [error 32] broken pipe caused by time out;
ldap3==2.4