### PR TITLE
Modernize documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ docs/django.inv
 
 .tox
 test_venv
+cas_venv
 .coverage
 htmlcov/
 tox_logs/

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,9 @@ CAS Server
 CAS Server is a Django application implementing the `CAS Protocol 3.0 Specification
 <https://apereo.github.io/cas/4.2.x/protocol/CAS-Protocol-Specification.html>`_.
 
-By default, the authentication process use django internal users but you can easily
-use any sources (see the `Authentication backend`_ section and auth classes in the auth.py file)
+By default, the authentication process use django internal users but you can
+easily use any sources (see the `Authentication backend`_ section and auth
+classes in the auth.py file)
 
 .. contents:: Table of Contents
 
@@ -35,48 +36,52 @@ Dependencies
 * lxml >= 3.4
 * six >= 1.8
 
-Minimal version of packages dependancy are just indicative and meens that ``django-cas-server`` has
-been tested with it. Previous versions of dependencies may or may not work.
+Minimal version of packages dependancy are just indicative and meens that
+``django-cas-server`` has been tested with it. Previous versions of
+dependencies may or may not work.
 
-Additionally, denpending of the `Authentication backend`_ you plan to use, you may need the following
-python packages:
+Additionally, denpending of the `Authentication backend`_ you plan to use,
+you may need the following python packages:
 
 * ldap3
 * psycopg2
 * mysql-python
 
+Here there is a table with the name of python packages and the corresponding
+packages providing them on debian like systems and centos like systems.
+You should try as much as possible to use system packages as there are
+automatically updated then you update your system.
+You can then install Not Available (N/A) packages on your system using pip
+inside a virtualenv as described in the `Installation`_ section.
 
-Here there is a table with the name of python packages and the corresponding packages providing
-them on debian like systems and centos like systems.
-You should try as much as possible to use system packages as there are automatically updated then
-you update your system. You can then install Not Available (N/A)
-packages on your system using pip inside a virtualenv as described in the `Installation`_ section.
-For use with python3, just replace python(2) in the table by python3.
-
-+------------------+-------------------------+---------------------+
-| python package   | debian like systems     | centos like systems |
-+==================+=========================+=====================+
-| Django           | python-django           | python-django       |
-+------------------+-------------------------+---------------------+
-| requests         | python-requests         | python-requests     |
-+------------------+-------------------------+---------------------+
-| requests_futures | python-requests-futures | N/A                 |
-+------------------+-------------------------+---------------------+
-| lxml             | python-lxml             | python-lxml         |
-+------------------+-------------------------+---------------------+
-| six              | python-six              | python-six          |
-+------------------+-------------------------+---------------------+
-| ldap3            | python-ldap3            | python-ldap3        |
-+------------------+-------------------------+---------------------+
-| psycopg2         | python-psycopg2         | python-psycopg2     |
-+------------------+-------------------------+---------------------+
-| mysql-python     | python-mysqldb          | python2-mysql       |
-+------------------+-------------------------+---------------------+
++------------------+--------------------------+---------------------+
+| python package   | debian like systems      | centos like systems |
++==================+==========================+=====================+
+| Django           | python3-django           | python-django       |
++------------------+--------------------------+---------------------+
+| requests         | python3-requests         | python-requests     |
++------------------+--------------------------+---------------------+
+| requests_futures | python3-requests-futures | N/A                 |
++------------------+--------------------------+---------------------+
+| lxml             | python3-lxml             | python-lxml         |
++------------------+--------------------------+---------------------+
+| six              | python3-six              | python-six          |
++------------------+--------------------------+---------------------+
+| ldap3            | python3-ldap3            | python-ldap3        |
++------------------+--------------------------+---------------------+
+| psycopg2         | python3-psycopg2         | python-psycopg2     |
++------------------+--------------------------+---------------------+
+| mysql-python     | python3-mysqldb          | python2-mysql       |
++------------------+--------------------------+---------------------+
 
 Installation
 ============
 
-The recommended installation mode is to use a virtualenv with ``--system-site-packages``
+On Debian-based system you can install ``python3-django-cas-server``
+but if you want the lastest version you can follow the following instructions.
+
+When creating a Python virtualenv, it is recommended to use system packages
+with ``--system-site-packages``.
 
 1. Make sure that python virtualenv is installed
 
@@ -84,10 +89,7 @@ The recommended installation mode is to use a virtualenv with ``--system-site-pa
 
    On debian like systems::
 
-    $ sudo apt-get install python-django python-requests python-six python-lxml python-requests-futures
-
-   On debian jessie, you can use the version of python-django available in the
-   `backports <https://backports.debian.org/Instructions/>`_.
+    $ sudo apt-get install python3-django python3-requests python3-six python3-lxml python3-requests-futures
 
    On centos like systems::
 
@@ -95,16 +97,11 @@ The recommended installation mode is to use a virtualenv with ``--system-site-pa
 
 3. Create a virtualenv::
 
-    $ virtualenv --system-site-packages cas_venv
-    Running virtualenv with interpreter /var/www/html/cas-server/bin/python2
-    Using real prefix '/usr'
-    New python executable in cas/bin/python2
-    Also creating executable in cas/bin/python
-    Installing setuptools, pip...done.
+    $ python3 -m venv --system-site-packages cas_venv
 
 4. And `activate it <https://virtualenv.pypa.io/en/stable/userguide/#activate-script>`__::
 
-    $ cd cas_venv/; . bin/activate
+    $ . cas_venv/bin/activate
 
 5. Create a django project::
 
@@ -126,7 +123,8 @@ The recommended installation mode is to use a virtualenv with ``--system-site-pa
    `PYTHONPATH <https://docs.python.org/2/using/cmdline.html#envvar-PYTHONPATH>`_
    (for instance by symlinking ``cas_server`` to the root of your django project).
 
-7. Open ``cas_project/settings.py`` in you favourite editor and follow the quick start section.
+7. Open ``cas_project/settings.py`` in you favourite editor and follow the
+   quick start section.
 
 
 Quick start
@@ -166,13 +164,15 @@ Quick start
    ``cas_clean_tickets`` and ``cas_clean_sessions``.
 
    * ``clearsessions``:  please see `Clearing the session store <https://docs.djangoproject.com/en/stable/topics/http/sessions/#clearing-the-session-store>`_.
-   * ``cas_clean_tickets``: old tickets and timed-out tickets do not get purge from
-     the database automatically. They are just marked as invalid. ``cas_clean_tickets``
-     is a clean-up management command for this purpose. It send SingleLogOut request
-     to services with timed out tickets and delete them.
-   * ``cas_clean_sessions``: Logout and purge users (sending SLO requests) that are
-     inactive since more than ``SESSION_COOKIE_AGE``. The default value for is ``1209600``
-     seconds (2 weeks). You probably should reduce it to something like ``86400`` seconds (1 day).
+   * ``cas_clean_tickets``: old tickets and timed-out tickets do not get purge
+     from the database automatically. They are just marked as invalid.
+     ``cas_clean_tickets`` is a clean-up management command for this purpose.
+     It send SingleLogOut request to services with timed out tickets and delete
+     them.
+   * ``cas_clean_sessions``: Logout and purge users (sending SLO requests) that
+     are inactive since more than ``SESSION_COOKIE_AGE``. The default value for
+     is ``1209600`` seconds (2 weeks).
+     You probably should reduce it to something like ``86400`` seconds (1 day).
 
    You could for example do as bellow::
 
@@ -184,17 +184,16 @@ Quick start
 
 6. Start the development server and visit http://127.0.0.1:8000/admin/
    to add a first service allowed to authenticate user against the CAS
-   (you'll need the Admin app enabled). See the `Service Patterns`_ section bellow.
+   (you'll need the Admin app enabled). See the `Service Patterns`_
+   section bellow.
 
 7. Visit http://127.0.0.1:8000/cas/ to login with your django users.
-
-
-
 
 Settings
 ========
 
-All settings are optional. Add them to ``settings.py`` to customize ``django-cas-server``:
+All settings are optional. Add them to ``settings.py`` to customize
+``django-cas-server``:
 
 
 Template settings
@@ -202,12 +201,15 @@ Template settings
 
 * ``CAS_LOGO_URL``: URL to the logo showed in the up left corner on the default
   templates. Set it to ``False`` to disable it.
-* ``CAS_FAVICON_URL``: URL to the favicon (shortcut icon) used by the default templates.
+* ``CAS_FAVICON_URL``: URL to the favicon (shortcut icon) used by the default
+  templates.
   Default is a key icon. Set it to ``False`` to disable it.
-* ``CAS_SHOW_POWERED``: Set it to ``False`` to hide the powered by footer. The default is ``True``.
-* ``CAS_COMPONENT_URLS``: URLs to css and javascript external components. It is a dictionnary
-  having the five following keys: ``"bootstrap3_css"``, ``"bootstrap3_js"``,
-  ``"html5shiv"``, ``"respond"``, ``"jquery"``. The default is::
+* ``CAS_SHOW_POWERED``: Set it to ``False`` to hide the powered by footer.
+  The default is ``True``.
+* ``CAS_COMPONENT_URLS``: URLs to css and javascript external components.
+  It is a dictionnary having the five following keys: ``"bootstrap3_css"``,
+  ``"bootstrap3_js"``, ``"html5shiv"``, ``"respond"``, ``"jquery"``.
+  The default is::
 
         {
             "bootstrap3_css": "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css",
@@ -217,18 +219,25 @@ Template settings
             "jquery": "//code.jquery.com/jquery.min.js",
         }
 
-  if you omit some keys of the dictionnary, the default value for these keys is used.
-* ``CAS_SHOW_SERVICE_MESSAGES``: Messages displayed about the state of the service on the login page.
+  if you omit some keys of the dictionnary, the default value for these keys is
+  used.
+* ``CAS_SHOW_SERVICE_MESSAGES``: Messages displayed about the state of the
+  service on the login page.
   The default is ``True``.
-* ``CAS_INFO_MESSAGES``: Messages displayed in info-boxes on the html pages of the default templates.
-  It is a dictionnary mapping message name to a message dict. A message dict has 3 keys:
+* ``CAS_INFO_MESSAGES``: Messages displayed in info-boxes on the html pages
+  of the default templates.
+  It is a dictionnary mapping message name to a message dict.
+  A message dict has 3 keys:
 
-  * ``message``: A unicode message to display, potentially wrapped around ugettex_lazy
-  * ``discardable``: A boolean, specify if the users can close the message info-box
-  * ``type``: One of info, success, info, warning, danger. The type of the info-box.
+  * ``message``: A unicode message to display, potentially wrapped around
+    ugettex_lazy
+  * ``discardable``: A boolean, specify if the users can close the message
+    info-box
+  * ``type``: One of info, success, info, warning, danger. The type of the
+    info-box.
 
-  ``CAS_INFO_MESSAGES`` contains by default one message, ``cas_explained``, which explain
-  roughly the purpose of a CAS. The default is::
+  ``CAS_INFO_MESSAGES`` contains by default one message, ``cas_explained``,
+  which explain roughly the purpose of a CAS. The default is::
 
     {
         "cas_explained": {
@@ -242,103 +251,137 @@ Template settings
         },
     }
 
-* ``CAS_INFO_MESSAGES_ORDER``: A list of message names. Order in which info-box messages are
-  displayed. Use an empty list to disable messages display. The default is ``[]``.
-* ``CAS_LOGIN_TEMPLATE``: Path to the template showed on ``/login`` then the user
-  is not autenticated.  The default is ``"cas_server/login.html"``.
-* ``CAS_WARN_TEMPLATE``: Path to the template showed on ``/login?service=...`` then
-  the user is authenticated and has asked to be warned before being connected
-  to a service. The default is ``"cas_server/warn.html"``.
-* ``CAS_LOGGED_TEMPLATE``: Path to the template showed on ``/login`` then to user is
-  authenticated. The default is ``"cas_server/logged.html"``.
-* ``CAS_LOGOUT_TEMPLATE``: Path to the template showed on ``/logout`` then to user
-  is being disconnected. The default is ``"cas_server/logout.html"``
-* ``CAS_REDIRECT_TO_LOGIN_AFTER_LOGOUT``: Should we redirect users to ``/login`` after they
-  logged out instead of displaying ``CAS_LOGOUT_TEMPLATE``. The default is ``False``.
+* ``CAS_INFO_MESSAGES_ORDER``: A list of message names. Order in which info-box
+  messages are displayed. Use an empty list to disable messages display.
+  The default is ``[]``.
+* ``CAS_LOGIN_TEMPLATE``: Path to the template showed on ``/login`` then the
+  user is not autenticated.
+  The default is ``"cas_server/login.html"``.
+* ``CAS_WARN_TEMPLATE``: Path to the template showed on ``/login?service=...``
+  then the user is authenticated and has asked to be warned before being
+  connected to a service.
+  The default is ``"cas_server/warn.html"``.
+* ``CAS_LOGGED_TEMPLATE``: Path to the template showed on ``/login`` then to
+  user is authenticated.
+  The default is ``"cas_server/logged.html"``.
+* ``CAS_LOGOUT_TEMPLATE``: Path to the template showed on ``/logout`` then to
+  user is being disconnected.
+  The default is ``"cas_server/logout.html"``
+* ``CAS_REDIRECT_TO_LOGIN_AFTER_LOGOUT``: Should we redirect users to
+  ``/login`` after they logged out instead of displaying
+  ``CAS_LOGOUT_TEMPLATE``.
+  The default is ``False``.
 
 
 Authentication settings
 -----------------------
 
 * ``CAS_AUTH_CLASS``: A dotted path to a class or a class implementing
-  ``cas_server.auth.AuthUser``. The default is ``"cas_server.auth.DjangoAuthUser"``
+  ``cas_server.auth.AuthUser``.
+  The default is ``"cas_server.auth.DjangoAuthUser"``
   Available classes bundled with ``django-cas-server`` are listed below in the
   `Authentication backend`_ section.
 
-* ``SESSION_COOKIE_AGE``: This is a django settings. Here, it control the delay in seconds after
-  which inactive users are logged out. The default is ``1209600`` (2 weeks). You probably should
-  reduce it to something like ``86400`` seconds (1 day).
+* ``SESSION_COOKIE_AGE``: This is a django settings. Here, it control the
+  delay in seconds after which inactive users are logged out.
+  The default is ``1209600`` (2 weeks).
+  You probably should reduce it to something like ``86400`` seconds (1 day).
 
-* ``CAS_TGT_VALIDITY``: Max time after with the user MUST reauthenticate. Let it to `None` for no
-  max time.This can be used to force refreshing cached informations only available upon user
-  authentication like the user attributes in federation mode or with the ldap auth in bind mode.
+* ``CAS_TGT_VALIDITY``: Max time after with the user MUST reauthenticate.
+  Let it to `None` for no max time.
+  This can be used to force refreshing cached informations only available upon
+  user authentication like the user attributes in federation mode or with the
+  ldap auth in bind mode.
   The default is ``None``.
 
-* ``CAS_PROXY_CA_CERTIFICATE_PATH``: Path to certificate authorities file. Usually on linux
-  the local CAs are in ``/etc/ssl/certs/ca-certificates.crt``. The default is ``True`` which
-  tell requests to use its internal certificat authorities. Settings it to ``False`` should
-  disable all x509 certificates validation and MUST not be done in production.
+* ``CAS_PROXY_CA_CERTIFICATE_PATH``: Path to certificate authorities file.
+  Usually on linux the local CAs are in ``/etc/ssl/certs/ca-certificates.crt``.
+  The default is ``True`` which tell requests to use its internal certificat
+  authorities. Settings it to ``False`` should disable all x509 certificates
+  validation and MUST not be done in production.
   x509 certificate validation is perform upon PGT issuance.
 
-* ``CAS_SLO_MAX_PARALLEL_REQUESTS``: Maximum number of parallel single log out requests send.
+* ``CAS_SLO_MAX_PARALLEL_REQUESTS``: Maximum number of parallel single log out
+  requests send.
   If more requests need to be send, there are queued. The default is ``10``.
-* ``CAS_SLO_TIMEOUT``: Timeout for a single SLO request in seconds. The default is ``5``.
+* ``CAS_SLO_TIMEOUT``: Timeout for a single SLO request in seconds.
+  The default is ``5``.
 
 
 Federation settings
 -------------------
 
-* ``CAS_FEDERATE``: A boolean for activating the federated mode (see the `Federation mode`_
-  section below). The default is ``False``.
-* ``CAS_FEDERATE_REMEMBER_TIMEOUT``: Time after witch the cookie use for "remember my identity
-  provider" expire. The default is ``604800``, one week. The cookie is called
-  ``_remember_provider``.
+* ``CAS_FEDERATE``: A boolean for activating the federated mode (see the
+  `Federation mode`_ section below).
+  The default is ``False``.
+* ``CAS_FEDERATE_REMEMBER_TIMEOUT``: Time after witch the cookie use for
+  "remember my identity provider" expire.
+  The default is ``604800``, one week.
+  The cookie is called ``_remember_provider``.
 
 
 New version warnings settings
 -----------------------------
 
-* ``CAS_NEW_VERSION_HTML_WARNING``: A boolean for diplaying a warning on html pages then a new
-  version of the application is avaible. Once closed by a user, it is not displayed to this user
-  until the next new version. The default is ``True``.
-* ``CAS_NEW_VERSION_EMAIL_WARNING``: A boolean for sending a email to ``settings.ADMINS`` when a new
-  version is available. The default is ``True``.
+* ``CAS_NEW_VERSION_HTML_WARNING``: A boolean for diplaying a warning on html
+  pages then a new version of the application is avaible.
+  Once closed by a user, it is not displayed to this user until the next new
+  version.
+  The default is ``True``.
+* ``CAS_NEW_VERSION_EMAIL_WARNING``: A boolean for sending a email to
+  ``settings.ADMINS`` when a new version is available.
+  The default is ``True``.
 
 
 Tickets validity settings
 -------------------------
 
-* ``CAS_TICKET_VALIDITY``: Number of seconds the service tickets and proxy tickets are valid.
-  This is the maximal time between ticket issuance by the CAS and ticket validation by an
-  application. The default is ``60``.
+* ``CAS_TICKET_VALIDITY``: Number of seconds the service tickets and proxy
+  tickets are valid.
+  This is the maximal time between ticket issuance by the CAS and ticket
+  validation by an application.
+  The default is ``60``.
 * ``CAS_PGT_VALIDITY``: Number of seconds the proxy granting tickets are valid.
   The default is ``3600`` (1 hour).
-* ``CAS_TICKET_TIMEOUT``: Number of seconds a ticket is kept in the database before sending
-  Single Log Out request and being cleared. The default is ``86400`` (24 hours).
+* ``CAS_TICKET_TIMEOUT``: Number of seconds a ticket is kept in the database
+  before sending Single Log Out request and being cleared.
+  The default is ``86400`` (24 hours).
+
 
 Tickets miscellaneous settings
 ------------------------------
 
-* ``CAS_TICKET_LEN``: Default ticket length. All CAS implementation MUST support ST and PT
-  up to 32 chars, PGT and PGTIOU up to 64 chars and it is RECOMMENDED that all tickets up
-  to 256 chars are supports. Here the default is ``64``.
-* ``CAS_LT_LEN``: Length of the login tickets. Login tickets are only processed by ``django-cas-server``
-  thus there is no length restriction on it. The default is ``CAS_TICKET_LEN``.
-* ``CAS_ST_LEN``: Length of the service tickets. The default is ``CAS_TICKET_LEN``.
+* ``CAS_TICKET_LEN``: Default ticket length. All CAS implementation MUST
+  support ST and PT up to 32 chars, PGT and PGTIOU up to 64 chars and it is
+  RECOMMENDED that all tickets up to 256 chars are supports.
+  Here the default is ``64``.
+* ``CAS_LT_LEN``: Length of the login tickets.
+  Login tickets are only processed by ``django-cas-server`` thus there is no
+  length restriction on it.
+  The default is ``CAS_TICKET_LEN``.
+* ``CAS_ST_LEN``: Length of the service tickets.
+  The default is ``CAS_TICKET_LEN``.
   You may need to lower is to ``32`` if you use some old clients.
-* ``CAS_PT_LEN``: Length of the proxy tickets. The default is ``CAS_TICKET_LEN``.
-  This length should be the same as ``CAS_ST_LEN``. You may need to lower is to ``32``
-  if you use some old clients.
-* ``CAS_PGT_LEN``: Length of the proxy granting tickets. The default is ``CAS_TICKET_LEN``.
-* ``CAS_PGTIOU_LEN``: Length of the proxy granting tickets IOU. The default is ``CAS_TICKET_LEN``.
+* ``CAS_PT_LEN``: Length of the proxy tickets.
+  The default is ``CAS_TICKET_LEN``.
+  This length should be the same as ``CAS_ST_LEN``.
+  You may need to lower is to ``32`` if you use some old clients.
+* ``CAS_PGT_LEN``: Length of the proxy granting tickets.
+  The default is ``CAS_TICKET_LEN``.
+* ``CAS_PGTIOU_LEN``: Length of the proxy granting tickets IOU.
+  The default is ``CAS_TICKET_LEN``.
 
-* ``CAS_LOGIN_TICKET_PREFIX``: Prefix of login tickets. The default is ``"LT"``.
-* ``CAS_SERVICE_TICKET_PREFIX``: Prefix of service tickets. The default is ``"ST"``.
-  The CAS specification mandate that service tickets MUST begin with the characters ST
-  so you should not change this.
+* ``CAS_LOGIN_TICKET_PREFIX``: Prefix of login tickets.
+  The default is ``"LT"``.
+* ``CAS_SERVICE_TICKET_PREFIX``: Prefix of service tickets.
+  The default is ``"ST"``.
+  The CAS specification mandate that service tickets MUST begin with the
+  characters ST so you should not change this.
 * ``CAS_PROXY_TICKET_PREFIX``: Prefix of proxy ticket. The default is ``"PT"``.
-* ``CAS_PROXY_GRANTING_TICKET_PREFIX``: Prefix of proxy granting ticket. The default is ``"PGT"``.
-* ``CAS_PROXY_GRANTING_TICKET_IOU_PREFIX``: Prefix of proxy granting ticket IOU. The default is ``"PGTIOU"``.
+* ``CAS_PROXY_GRANTING_TICKET_PREFIX``: Prefix of proxy granting ticket.
+  The default is ``"PGT"``.
+* ``CAS_PROXY_GRANTING_TICKET_IOU_PREFIX``: Prefix of proxy granting ticket
+  IOU. The default is ``"PGTIOU"``.
 
 
 Mysql backend settings
@@ -355,16 +398,19 @@ Only usefull if you are using the mysql authentication backend:
   The username must be in field ``username``, the password in ``password``,
   additional fields are used as the user attributes.
   The default is ``"SELECT user AS username, pass AS password, users.* FROM users WHERE user = %s"``
-* ``CAS_SQL_PASSWORD_CHECK``: The method used to check the user password. Must be one of the following:
+* ``CAS_SQL_PASSWORD_CHECK``: The method used to check the user password.
+  Must be one of the following:
 
   * ``"crypt"`` (see <https://en.wikipedia.org/wiki/Crypt_(C)>), the password in the database
     should begin this $
   * ``"ldap"`` (see https://tools.ietf.org/id/draft-stroeder-hashed-userpassword-values-01.html)
-    the password in the database must begin with one of {MD5}, {SMD5}, {SHA}, {SSHA}, {SHA256},
-    {SSHA256}, {SHA384}, {SSHA384}, {SHA512}, {SSHA512}, {CRYPT}.
-  * ``"hex_HASH_NAME"`` with ``HASH_NAME`` in md5, sha1, sha224, sha256, sha384, sha512.
-    The hashed password in the database is compare to the hexadecimal digest of the clear
-    password hashed with the corresponding algorithm.
+    the password in the database must begin with one of {MD5}, {SMD5}, {SHA},
+    {SSHA}, {SHA256}, {SSHA256}, {SHA384}, {SSHA384}, {SHA512}, {SSHA512},
+    {CRYPT}.
+  * ``"hex_HASH_NAME"`` with ``HASH_NAME`` in md5, sha1, sha224, sha256,
+    sha384, sha512.
+    The hashed password in the database is compare to the hexadecimal digest of
+    the clear password hashed with the corresponding algorithm.
   * ``"plain"``, the password in the database must be in clear.
 
   The default is ``"crypt"``.
@@ -372,8 +418,9 @@ Only usefull if you are using the mysql authentication backend:
 
 Sql backend settings
 --------------------
-Only usefull if you are using the sql authentication backend. You must add a ``"cas_server"``
-database to `settings.DATABASES <https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DATABASES>`__
+Only usefull if you are using the sql authentication backend.
+You must add a ``"cas_server"`` database to
+`settings.DATABASES <https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DATABASES>`__
 as defined in the django documentation. It is then the database
 use by the sql backend.
 
@@ -381,59 +428,81 @@ use by the sql backend.
   The username must be in field ``username``, the password in ``password``,
   additional fields are used as the user attributes.
   The default is ``"SELECT user AS username, pass AS password, users.* FROM users WHERE user = %s"``
-* ``CAS_SQL_PASSWORD_CHECK``: The method used to check the user password. Must be one of the following:
+* ``CAS_SQL_PASSWORD_CHECK``: The method used to check the user password.
+  Must be one of the following:
 
   * ``"crypt"`` (see <https://en.wikipedia.org/wiki/Crypt_(C)>), the password in the database
     should begin this $
   * ``"ldap"`` (see https://tools.ietf.org/id/draft-stroeder-hashed-userpassword-values-01.html)
-    the password in the database must begin with one of {MD5}, {SMD5}, {SHA}, {SSHA}, {SHA256},
-    {SSHA256}, {SHA384}, {SSHA384}, {SHA512}, {SSHA512}, {CRYPT}.
-  * ``"hex_HASH_NAME"`` with ``HASH_NAME`` in md5, sha1, sha224, sha256, sha384, sha512.
-    The hashed password in the database is compare to the hexadecimal digest of the clear
-    password hashed with the corresponding algorithm.
+    the password in the database must begin with one of {MD5}, {SMD5}, {SHA},
+    {SSHA}, {SHA256}, {SSHA256}, {SHA384}, {SSHA384}, {SHA512}, {SSHA512},
+    {CRYPT}.
+  * ``"hex_HASH_NAME"`` with ``HASH_NAME`` in md5, sha1, sha224, sha256,
+    sha384, sha512.
+    The hashed password in the database is compare to the hexadecimal digest
+    of the clear password hashed with the corresponding algorithm.
   * ``"plain"``, the password in the database must be in clear.
 
   The default is ``"crypt"``.
-* ``CAS_SQL_PASSWORD_CHARSET``: Charset the SQL users passwords was hash with. This is needed to
-  encode the user sended password before hashing it for comparison. The default is ``"utf-8"``.
+* ``CAS_SQL_PASSWORD_CHARSET``: Charset the SQL users passwords was hash with.
+  This is needed to encode the user sended password before hashing it for
+  comparison.
+  The default is ``"utf-8"``.
 
 
 Ldap backend settings
 ---------------------
 Only usefull if you are using the ldap authentication backend:
 
-* ``CAS_LDAP_SERVER``: Address of the LDAP server. The default is ``"localhost"``.
-* ``CAS_LDAP_USER``: User bind address, for example ``"cn=admin,dc=crans,dc=org"`` for
-  connecting to the LDAP server.
+* ``CAS_LDAP_SERVER``: Address of the LDAP server.
+  The default is ``"localhost"``.
+* ``CAS_LDAP_USER``: User bind address, for example
+  ``"cn=admin,dc=crans,dc=org"`` for connecting to the LDAP server.
 * ``CAS_LDAP_PASSWORD``: Password for connecting to the LDAP server.
-* ``CAS_LDAP_BASE_DN``: LDAP search base DN, for example ``"ou=data,dc=crans,dc=org"``.
-* ``CAS_LDAP_USER_QUERY``: Search filter for searching user by username. User inputed usernames are
-  escaped using ``ldap3.utils.conv.escape_bytes``. The default is ``"(uid=%s)"``
-* ``CAS_LDAP_USERNAME_ATTR``: Attribute used for users usernames. The default is ``"uid"``
-* ``CAS_LDAP_PASSWORD_ATTR``: Attribute used for users passwords. The default is ``"userPassword"``
-* ``CAS_LDAP_PASSWORD_CHECK``: The method used to check the user password. Must be one of the following:
+* ``CAS_LDAP_BASE_DN``: LDAP search base DN, for example
+  ``"ou=data,dc=crans,dc=org"``.
+* ``CAS_LDAP_USER_QUERY``: Search filter for searching user by username.
+  User inputed usernames are escaped using ``ldap3.utils.conv.escape_bytes``.
+  The default is ``"(uid=%s)"``
+* ``CAS_LDAP_USERNAME_ATTR``: Attribute used for users usernames.
+  The default is ``"uid"``
+* ``CAS_LDAP_PASSWORD_ATTR``: Attribute used for users passwords.
+  The default is ``"userPassword"``
+* ``CAS_LDAP_PASSWORD_CHECK``: The method used to check the user password.
+  Must be one of the following:
 
   * ``"crypt"`` (see <https://en.wikipedia.org/wiki/Crypt_(C)>), the password in the database
     should begin this $
   * ``"ldap"`` (see https://tools.ietf.org/id/draft-stroeder-hashed-userpassword-values-01.html)
-    the password in the database must begin with one of {MD5}, {SMD5}, {SHA}, {SSHA}, {SHA256},
-    {SSHA256}, {SHA384}, {SSHA384}, {SHA512}, {SSHA512}, {CRYPT}.
-  * ``"hex_HASH_NAME"`` with ``HASH_NAME`` in md5, sha1, sha224, sha256, sha384, sha512.
-    The hashed password in the database is compare to the hexadecimal digest of the clear
-    password hashed with the corresponding algorithm.
+    the password in the database must begin with one of {MD5}, {SMD5}, {SHA},
+    {SSHA}, {SHA256}, {SSHA256}, {SHA384}, {SSHA384}, {SHA512}, {SSHA512},
+    {CRYPT}.
+  * ``"hex_HASH_NAME"`` with ``HASH_NAME`` in md5, sha1, sha224, sha256,
+    sha384, sha512.
+    The hashed password in the database is compare to the hexadecimal digest of
+    the clear password hashed with the corresponding algorithm.
   * ``"plain"``, the password in the database must be in clear.
-  * ``"bind``, the user credentials are used to bind to the ldap database and retreive the user
-    attribute. In this mode, the settings ``CAS_LDAP_PASSWORD_ATTR`` and ``CAS_LDAP_PASSWORD_CHARSET``
-    are ignored, and it is the ldap server that perform password check. The counterpart is that
-    the user attributes are only available upon user password check and so are cached for later
-    use. All the other modes directly fetch the user attributes from the database whenever there
-    are needed. This mean that is you use this mode, they can be some difference between the
-    attributes in database and the cached ones if changes happend in the database after the user
-    authentiate. See the parameter ``CAS_TGT_VALIDITY`` to force user to reauthenticate periodically.
+  * ``"bind``, the user credentials are used to bind to the ldap database and
+    retreive the user attribute.
+    In this mode, the settings ``CAS_LDAP_PASSWORD_ATTR`` and
+    ``CAS_LDAP_PASSWORD_CHARSET`` are ignored, and it is the ldap server that
+    perform password check.
+    The counterpart is that the user attributes are only available upon user
+    password check and so are cached for later use.
+    All the other modes directly fetch the user attributes from the database
+    whenever there are needed.
+    This mean that is you use this mode, they can be some difference between
+    the attributes in database and the cached ones if changes happend in the
+    database after the user authentiate.
+    See the parameter ``CAS_TGT_VALIDITY`` to force user to reauthenticate
+    periodically.
 
   The default is ``"ldap"``.
-* ``CAS_LDAP_PASSWORD_CHARSET``: Charset the LDAP users passwords was hash with. This is needed to
-  encode the user sended password before hashing it for comparison. The default is ``"utf-8"``.
+* ``CAS_LDAP_PASSWORD_CHARSET``: Charset the LDAP users passwords was hash
+  with.
+  This is needed to encode the user sended password before hashing it for
+  comparison.
+  The default is ``"utf-8"``.
 
 
 Test backend settings
@@ -452,30 +521,40 @@ Authentication backend
 
 ``django-cas-server`` comes with some authentication backends:
 
-* dummy backend ``cas_server.auth.DummyAuthUser``: all authentication attempt fails.
-* test backend ``cas_server.auth.TestAuthUser``: username, password and returned attributes
-  for the user are defined by the ``CAS_TEST_*`` settings.
-* django backend ``cas_server.auth.DjangoAuthUser``: Users are authenticated against django users system.
-  This is the default backend. The returned attributes are the fields available on the user model.
-* mysql backend ``cas_server.auth.MysqlAuthUser``: Deprecated, use the sql backend instead.
-  see the `Mysql backend settings`_ section. The returned attributes are those return by sql query
-  ``CAS_SQL_USER_QUERY``.
-* sql backend ``cas_server.auth.SqlAuthUser``: see the `Sql backend settings`_ section.
+* dummy backend ``cas_server.auth.DummyAuthUser``: all authentication attempt
+  fails.
+* test backend ``cas_server.auth.TestAuthUser``: username, password and
+  returned attributes for the user are defined by the ``CAS_TEST_*`` settings.
+* django backend ``cas_server.auth.DjangoAuthUser``: Users are authenticated
+  against django users system.
+  This is the default backend.
+  The returned attributes are the fields available on the user model.
+* mysql backend ``cas_server.auth.MysqlAuthUser``: Deprecated, use the sql
+  backend instead.
+  see the `Mysql backend settings`_ section. The returned attributes are those
+  return by sql query ``CAS_SQL_USER_QUERY``.
+* sql backend ``cas_server.auth.SqlAuthUser``: see the `Sql backend settings`_
+  section.
   The returned attributes are those return by sql query ``CAS_SQL_USER_QUERY``.
-* ldap backend ``cas_server.auth.LdapAuthUser``: see the `Ldap backend settings`_ section.
-  The returned attributes are those of the ldap node returned by the query filter ``CAS_LDAP_USER_QUERY``.
-* federated backend ``cas_server.auth.CASFederateAuth``: It is automatically used then ``CAS_FEDERATE`` is ``True``.
+* ldap backend ``cas_server.auth.LdapAuthUser``: see the
+  `Ldap backend settings`_ section.
+  The returned attributes are those of the ldap node returned by the query
+  filter ``CAS_LDAP_USER_QUERY``.
+* federated backend ``cas_server.auth.CASFederateAuth``: It is automatically
+  used then ``CAS_FEDERATE`` is ``True``.
   You should not set it manually without setting ``CAS_FEDERATE`` to ``True``.
 
 
 Logs
 ====
 
-``django-cas-server`` logs most of its actions. To enable login, you must set the ``LOGGING``
-(https://docs.djangoproject.com/en/stable/topics/logging) variable in ``settings.py``.
+``django-cas-server`` logs most of its actions. To enable login, you must set
+the ``LOGGING`` (https://docs.djangoproject.com/en/stable/topics/logging)
+variable in ``settings.py``.
 
-Users successful actions (login, logout) are logged with the level ``INFO``, failures are logged
-with the level ``WARNING`` and user attributes transmitted to a service are logged with the level ``DEBUG``.
+Users successful actions (login, logout) are logged with the level ``INFO``,
+failures are logged with the level ``WARNING`` and user attributes transmitted
+to a service are logged with the level ``DEBUG``.
 
 For example to log to syslog you can use :
 
@@ -539,51 +618,69 @@ Or to log to a file:
 Service Patterns
 ================
 
-In a CAS context, ``Service`` refers to the application the client is trying to access.
+In a CAS context, ``Service`` refers to the application the client is trying to
+access.
 By extension we use ``service`` for the URL of such an application.
 
-By default, ``django-cas-server`` do not allow any service to use the CAS to authenticate users.
+By default, ``django-cas-server`` do not allow any service to use the CAS to
+authenticate users.
 In order to allow services, you need to connect to the django admin interface using a django
 superuser, and add a first service pattern.
 
 A service pattern comes with 9 fields:
 
-* ``Position``: an integer used to change the order in which services are matched against
-  service patterns.
-* ``Name``: the name of the service pattern. It will be displayed to the users asking for a ticket
-  for a service matching this service pattern on the login page.
+* ``Position``: an integer used to change the order in which services are
+  matched against service patterns.
+* ``Name``: the name of the service pattern. It will be displayed to the users
+  asking for a ticket for a service matching this service pattern on the login
+  page.
 * ``Pattern``: a regular expression used to match services.
-* ``User field``: the user attribute to use as username for services matching this service pattern.
+* ``User field``: the user attribute to use as username for services matching
+  this service pattern.
   Leave it empty to use the login name.
-* ``Restrict username``: if checked, only login name defined below are allowed to get tickets
-  for services matching this service pattern.
-* ``Proxy``: if checked, allow the creation of Proxy Ticket for services matching this
-  service pattern. Otherwise, only Service Ticket will be created.
-* ``Proxy callback``: if checked, services matching this service pattern are allowed to retrieve Proxy
-  Granting Ticket. A service with a Proxy Granting Ticket can get Proxy Ticket for other services.
-  Hence you must only check this for trusted services that need it. (For instance, a webmail needs
-  Proxy Ticket to authenticate himself as the user to the imap server).
-* ``Single log out``: Check it to send Single Log Out requests to authenticated services matching
-  this service pattern. SLO requests are send to all services the user is authenticated to then
-  the user disconnect.
-* ``Single log out callback``: The http(s) URL to POST the SLO requests. If empty, the service URL
-  is used. This field is useful to allow non http services (imap, smtp, ftp) to handle SLO requests.
+* ``Restrict username``: if checked, only login name defined below are allowed
+  to get tickets for services matching this service pattern.
+* ``Proxy``: if checked, allow the creation of Proxy Ticket for services
+  matching this service pattern.
+  Otherwise, only Service Ticket will be created.
+* ``Proxy callback``: if checked, services matching this service pattern are
+  allowed to retrieve Proxy Granting Ticket.
+  A service with a Proxy Granting Ticket can get Proxy Ticket for other
+  services.
+  Hence you must only check this for trusted services that need it.
+  (For instance, a webmail needs Proxy Ticket to authenticate himself as the
+  user to the imap server).
+* ``Single log out``: Check it to send Single Log Out requests to authenticated
+  services matching this service pattern.
+  SLO requests are send to all services the user is authenticated to then the
+  user disconnect.
+* ``Single log out callback``: The http(s) URL to POST the SLO requests.
+  If empty, the service URL is used.
+  This field is useful to allow non http services (imap, smtp, ftp) to handle
+  SLO requests.
 
 A service pattern has 4 associated models:
 
-* ``Usernames``: a list of username associated with the ``Restrict username`` field
-* ``Replace attribut names``: a list of user attributes to send to the service. Choose the name
-  used for sending the attribute by setting ``Remplacement`` or leave it empty to leave it unchanged.
-* ``Replace attribut values``: a list of sent user attributes for which value needs to be tweak.
-  Replace the attribute value by the string obtained by replacing the leftmost non-overlapping
-  occurrences of ``pattern`` in string by ``replace``. In ``replace`` backslash escapes are processed.
+* ``Usernames``: a list of username associated with the ``Restrict username``
+  field
+* ``Replace attribut names``: a list of user attributes to send to the service.
+  Choose the name used for sending the attribute by setting ``Remplacement`` or
+  leave it empty to leave it unchanged.
+* ``Replace attribut values``: a list of sent user attributes for which value
+  needs to be tweak.
+  Replace the attribute value by the string obtained by replacing the leftmost
+  non-overlapping occurrences of ``pattern`` in string by ``replace``.
+  In ``replace`` backslash escapes are processed.
   Matched groups are captures by \1, \2, etc.
-* ``Filter attribut values``: a list of user attributes for which value needs to match a regular
-  expression. For instance, service A may need an email address, and you only want user with
-  an email address to connect to it. To do so, put ``email`` in ``Attribute`` and ``.*`` in ``pattern``.
+* ``Filter attribut values``: a list of user attributes for which value needs
+  to match a regular expression.
+  For instance, service A may need an email address, and you only want user
+  with an email address to connect to it.
+  To do so, put ``email`` in ``Attribute`` and ``.*`` in ``pattern``.
 
-Then a user ask a ticket for a service, the service URL is compare against each service patterns
-sorted by ``position``. The first service pattern that matches the service URL is chosen.
+Then a user ask a ticket for a service, the service URL is compare against each
+service patterns sorted by ``position``.
+The first service pattern that matches the service URL is chosen.
 Hence, you should give low ``position`` to very specific patterns like
 ``^https://www\.example\.com(/.*)?$`` and higher ``position`` to generic patterns like ``^https://.*``.
 So the service URL ``https://www.examle.com`` will use the service pattern for
@@ -593,45 +690,55 @@ So the service URL ``https://www.examle.com`` will use the service pattern for
 Federation mode
 ===============
 
-``django-cas-server`` comes with a federation mode. Then ``CAS_FEDERATE`` is ``True``,
-user are invited to choose an identity provider on the login page, then, they are redirected
-to the provider CAS to authenticate. This provider transmit to ``django-cas-server`` the user
-username and attributes. The user is now logged in on ``django-cas-server`` and can use
-services using ``django-cas-server`` as CAS.
+``django-cas-server`` comes with a federation mode. When ``CAS_FEDERATE`` is
+``True``, user are invited to choose an identity provider on the login page,
+then, they are redirected to the provider CAS to authenticate.
+This provider transmit to ``django-cas-server`` the user
+username and attributes.
+The user is now logged in on ``django-cas-server`` and can use services using
+``django-cas-server`` as CAS.
 
-In federation mode, the user attributes are cached upon user authentication. See the settings
-``CAS_TGT_VALIDITY`` to force users to reauthenticate periodically and allow ``django-cas-server``
-to refresh cached attributes.
+In federation mode, the user attributes are cached upon user authentication.
+See the settings ``CAS_TGT_VALIDITY`` to force users to reauthenticate
+periodically and allow ``django-cas-server`` to refresh cached attributes.
 
-The list of allowed identity providers is defined using the django admin application.
+The list of allowed identity providers is defined using the django admin
+application.
 With the development server started, visit http://127.0.0.1:8000/admin/ to add identity providers.
 
 An identity provider comes with 5 fields:
 
-* ``Position``: an integer used to tweak the order in which identity providers are displayed on
-  the login page. Identity providers are sorted using position first, then, on equal position,
+* ``Position``: an integer used to tweak the order in which identity providers
+  are displayed on the login page.
+  Identity providers are sorted using position first, then, on equal position,
   using ``verbose name`` and then, on equal ``verbose name``, using ``suffix``.
-* ``Suffix``: the suffix that will be append to the username returned by the identity provider.
+* ``Suffix``: the suffix that will be append to the username returned by the
+  identity provider.
   It must be unique.
-* ``Server url``: the URL to the identity provider CAS. For instance, if you are using
-  ``https://cas.example.org/login`` to authenticate on the CAS, the ``server url`` is
-  ``https://cas.example.org``
-* ``CAS protocol version``: the version of the CAS protocol to use to contact the identity provider.
+* ``Server url``: the URL to the identity provider CAS. For instance, if you
+  are using ``https://cas.example.org/login`` to authenticate on the CAS, the
+  ``server url`` is ``https://cas.example.org``
+* ``CAS protocol version``: the version of the CAS protocol to use to contact
+  the identity provider.
   The default is version 3.
-* ``Verbose name``: the name used on the login page to display the identity provider.
-* ``Display``: a boolean controlling the display of the identity provider on the login page.
-  Beware that this do not disable the identity provider, it just hide it on the login page.
-  User will always be able to log in using this provider by fetching ``/federate/provider_suffix``.
+* ``Verbose name``: the name used on the login page to display the identity
+  provider.
+* ``Display``: a boolean controlling the display of the identity provider on
+  the login page.
+  Beware that this do not disable the identity provider, it just hide it on
+  the login page.
+  User will always be able to log in using this provider by fetching
+  ``/federate/provider_suffix``.
 
 
 In federation mode, ``django-cas-server`` build user's username as follow:
 ``provider_returned_username@provider_suffix``.
-Choose the provider returned username for ``django-cas-server`` and the provider suffix
-in order to make sense, as this built username is likely to be displayed to end users in
-applications.
+Choose the provider returned username for ``django-cas-server`` and the
+provider suffix in order to make sense, as this built username is likely to be
+displayed to end users in applications.
 
-
-Then using federate mode, you should add one command to a daily crontab: ``cas_clean_federate``.
+Then using federate mode, you should add one command to a daily crontab:
+``cas_clean_federate``.
 This command clean the local cache of federated user from old unused users.
 
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,3 @@
+*.db
+static
+settings_local.py

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -1,0 +1,160 @@
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License version 3 for
+# more details.
+#
+# You should have received a copy of the GNU General Public License version 3
+# along with this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# (c) 2019 Alexandre Iooss
+"""
+Django settings for example project.
+"""
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import os
+
+from django.utils.translation import gettext_lazy as _
+
+# Compatibility with Bootstrap 3
+from django.contrib.messages import constants as messages
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = 'CHANGE_ME_PLEASE_I_AM_VERY_IMPORTANT'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ADMINS = (
+    #('Admin', 'webmaster@example.com'),
+)
+
+SITE_ID = 1
+
+ALLOWED_HOSTS = []
+
+# Application definition
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.admindocs',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'cas_server',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.contrib.admindocs.middleware.XViewMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
+]
+
+ROOT_URLCONF = 'example.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'debug':
+            DEBUG,
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'example.wsgi.application'
+
+# Database
+# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'example.db'),
+    }
+}
+
+# Password validation
+# https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME':
+        'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME':
+        'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME':
+        'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME':
+        'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+# Internationalization
+# https://docs.djangoproject.com/en/2.2/topics/i18n/
+
+LANGUAGE_CODE = 'en'
+
+LANGUAGES = [
+    ('en', _('English')),
+    ('fr', _('French')),
+    ('nl', _('Dutch')),
+    ('pt_BR', _('Portuguese')),
+]
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/2.2/howto/static-files/
+
+# Absolute path to the directory static files should be collected to.
+# Don't put anything in this directory yourself; store your static files
+# in apps' "static/" subdirectories and in STATICFILES_DIRS.
+# Example: "/var/www/example.com/static/"
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+# URL prefix for static files.
+# Example: "http://example.com/static/", "http://static.example.com/"
+STATIC_URL = '/static/'
+
+# Customize these settings in a seperate config file
+try:
+    from settings_local import *
+except ImportError:
+    pass

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -17,16 +17,17 @@ import os
 
 from django.utils.translation import gettext_lazy as _
 
-# Compatibility with Bootstrap 3
-from django.contrib.messages import constants as messages
-
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'CHANGE_ME_PLEASE_I_AM_VERY_IMPORTANT'
+# Customize these settings in settings_local.py file
+try:
+    from settings_local import *
+except ImportError:
+    # SECURITY WARNING: keep the secret key used in production secret!
+    SECRET_KEY = 'CHANGE_ME_PLEASE_I_AM_VERY_IMPORTANT'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -152,9 +153,3 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 # URL prefix for static files.
 # Example: "http://example.com/static/", "http://static.example.com/"
 STATIC_URL = '/static/'
-
-# Customize these settings in a seperate config file
-try:
-    from settings_local import *
-except ImportError:
-    pass

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,0 +1,32 @@
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License version 3 for
+# more details.
+#
+# You should have received a copy of the GNU General Public License version 3
+# along with this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# (c) 2019 Alexandre Iooss
+
+from django.conf.urls import include, url
+from django.contrib import admin
+from django.views.generic import RedirectView
+
+urlpatterns = [
+    # No app, so redirect to admin
+    url(r'^$',
+        RedirectView.as_view(pattern_name='cas_server:login'),
+        name='index'),
+    url(r'^cas/', include('cas_server.urls', namespace="cas_server")),
+
+    # Include Django Contrib and Core routers
+    url(r'^i18n/', include('django.conf.urls.i18n')),
+    url(r'^accounts/login/',
+        RedirectView.as_view(pattern_name='index'),
+        name='login'),
+    url(r'^accounts/', include('django.contrib.auth.urls')),
+    url(r'^accounts/profile/', RedirectView.as_view(pattern_name='index')),
+    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    url(r'^admin/', admin.site.urls),
+]

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -8,6 +8,11 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # (c) 2019 Alexandre Iooss
+"""
+Router for the example project
+
+It also routes Django Admin, AdminDocs and Auth
+"""
 
 from django.conf.urls import include, url
 from django.contrib import admin

--- a/example/example/wsgi.py
+++ b/example/example/wsgi.py
@@ -1,0 +1,26 @@
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License version 3 for
+# more details.
+#
+# You should have received a copy of the GNU General Public License version 3
+# along with this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# (c) 2019 Alexandre Iooss
+"""
+WSGI config for this example project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/2.2/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'example.settings')
+
+application = get_wsgi_application()


### PR DESCRIPTION
This PR upgrades README instructions to Python3. I also included an `example` folder containing a reference implementation of django-cas-server in a Django project.