### PR TITLE
Bootstrap 4 templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,14 +206,12 @@ Template settings
   Default is a key icon. Set it to ``False`` to disable it.
 * ``CAS_SHOW_POWERED``: Set it to ``False`` to hide the powered by footer. The default is ``True``.
 * ``CAS_COMPONENT_URLS``: URLs to css and javascript external components. It is a dictionnary
-  having the five following keys: ``"bootstrap3_css"``, ``"bootstrap3_js"``,
-  ``"html5shiv"``, ``"respond"``, ``"jquery"``. The default is::
+  having the five following keys: ``"bootstrap3_css"``, ``"bootstrap3_js"``, ``"jquery"``.
+  The default is::
 
         {
-            "bootstrap3_css": "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css",
-            "bootstrap3_js": "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js",
-            "html5shiv": "//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js",
-            "respond": "//oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js",
+            "bootstrap4_css": "//stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css",
+            "bootstrap4_js": "//stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js",
             "jquery": "//code.jquery.com/jquery.min.js",
         }
 

--- a/cas_server/default_settings.py
+++ b/cas_server/default_settings.py
@@ -35,10 +35,8 @@ except ValueError:
 CAS_SHOW_POWERED = True
 #: URLs to css and javascript external components.
 CAS_COMPONENT_URLS = {
-    "bootstrap3_css": "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css",
-    "bootstrap3_js": "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js",
-    "html5shiv": "//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js",
-    "respond": "//oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js",
+    "bootstrap4_css": "//stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css",
+    "bootstrap4_js": "//stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js",
     "jquery": "//code.jquery.com/jquery.min.js",
 }
 #: Path to the template showed on /login then the user is not autenticated.

--- a/cas_server/static/cas_server/fa-lock.svg
+++ b/cas_server/static/cas_server/fa-lock.svg
@@ -1,0 +1,2 @@
+<!-- Icon by Font Awesome, https://fontawesome.com/, Creative Common 4.0 Attribution -->
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="lock" class="svg-inline--fa fa-lock fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M400 224h-24v-72C376 68.2 307.8 0 224 0S72 68.2 72 152v72H48c-26.5 0-48 21.5-48 48v192c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V272c0-26.5-21.5-48-48-48zm-104 0H152v-72c0-39.7 32.3-72 72-72s72 32.3 72 72v72z"></path></svg>

--- a/cas_server/static/cas_server/fa-user.svg
+++ b/cas_server/static/cas_server/fa-user.svg
@@ -1,0 +1,2 @@
+<!-- Icon by Font Awesome, https://fontawesome.com/, Creative Common 4.0 Attribution -->
+<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="user" class="svg-inline--fa fa-user fa-w-14" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M224 256c70.7 0 128-57.3 128-128S294.7 0 224 0 96 57.3 96 128s57.3 128 128 128zm89.6 32h-16.7c-22.2 10.2-46.9 16-72.9 16s-50.6-5.8-72.9-16h-16.7C60.2 288 0 348.2 0 422.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-41.6c0-74.2-60.2-134.4-134.4-134.4z"></path></svg>

--- a/cas_server/static/cas_server/styles.css
+++ b/cas_server/static/cas_server/styles.css
@@ -1,75 +1,34 @@
 html, body {
-    height: 100%;
-}
-body {
-  padding-top: 40px;
-  padding-bottom: 0;
+  height: 100%;
   background-color: #eee;
 }
-
-.form-signin .form-signin-heading,
-.form-signin .checkbox {
-  margin-bottom: 10px;
-}
-.form-signin .checkbox {
-  font-weight: normal;
-}
-.form-signin .form-control {
-  position: relative;
-  height: auto;
-  -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-          box-sizing: border-box;
-  padding: 10px;
-  font-size: 16px;
-}
-.form-signin .form-control:focus {
-  z-index: 2;
-}
-.form-signin input[type="text"] {
-  margin-bottom: -1px;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.form-signin input[type="password"] {
-  margin-bottom: 10px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+.cover-container {
+  max-width: 50em;
 }
 
+/* Page title */
 #app-name {
-    text-align: center;
+  color: #000;
+  text-shadow: 0 .05rem .2rem rgba(255, 255, 255, .5);
 }
 #app-name img {
-     width:110px;
+  width: 110px;
+  margin-right: 1rem;
 }
-
-/* Wrapper for page content to push down footer */
-#wrap {
-    min-height: 100%;
-    height: auto;
-    height: 100%;
-    /* Negative indent footer by it's height */
-    margin: 0 auto -40px;
-}
-#footer {
-    height: 40px;
-    text-align: center;
-}
-#footer p {
-  padding-top: 10px;
-}
-
 @media screen and (max-width: 680px) {
-    #app-name {
-        margin: 0;
-    }
-    #app-name img {
-        display: block;
-        margin: auto;
-    }
-    body {
-      padding-top: 0;
-      padding-bottom: 0;
-    }
+  #app-name img {
+      display: block;
+      margin: auto;
+  }
+}
+
+/* Add icons to login form */
+/* Font-Awesome attribution is already done inside SVG files */
+.form-signin input[type="text"] {
+  background: right 1rem top 50% / 5% no-repeat url('fa-user.svg');
+  padding-right: 3rem;
+}
+.form-signin input[type="password"] {
+  background: right 1rem top 50% / 5% no-repeat url('fa-lock.svg');
+  padding-right: 3rem;
 }

--- a/cas_server/templates/cas_server/base.html
+++ b/cas_server/templates/cas_server/base.html
@@ -31,35 +31,29 @@
         </header>
         {% if auto_submit %}</noscript>{% endif %}
 
-        <div class="row justify-content-center">
-          <main class="card border-dark" style="max-width: 30rem;">
-            {% if auto_submit %}<noscript>{% endif %}
-            <div class="card-header text-center">
-              {% block ante_messages %}{% endblock %}
-            </div>
-            {% if auto_submit %}</noscript>{% endif %}
-            <div class="card-body">
-              {% for message in messages %}
-                  <div {% spaceless %}
-                      {% if message.level == message_levels.DEBUG %}
-                          class="alert alert-warning"
-                      {% elif message.level == message_levels.INFO %}
-                          class="alert alert-info"
-                      {% elif message.level == message_levels.SUCCESS %}
-                          class="alert alert-success"
-                      {% elif message.level == message_levels.WARNING %}
-                          class="alert alert-warning"
-                      {% else %}
-                          class="alert alert-danger"
-                      {% endif %}
-                  {% endspaceless %}>
-                      <p>{{message}}</p>
-                  </div>
-              {% endfor %}
-              {% block content %}{% endblock %}
-            </div>
-          </main>
-        </div>
+        <main class="card border-dark mx-auto" style="max-width: 30rem;">
+          {% block ante_messages %}{% endblock %}
+          <div class="card-body">
+            {% for message in messages %}
+              <div {% spaceless %}
+                  {% if message.level == message_levels.DEBUG %}
+                      class="alert alert-warning"
+                  {% elif message.level == message_levels.INFO %}
+                      class="alert alert-info"
+                  {% elif message.level == message_levels.SUCCESS %}
+                      class="alert alert-success"
+                  {% elif message.level == message_levels.WARNING %}
+                      class="alert alert-warning"
+                  {% else %}
+                      class="alert alert-danger"
+                  {% endif %}
+              {% endspaceless %}>
+                  <p>{{message}}</p>
+              </div>
+            {% endfor %}
+            {% block content %}{% endblock %}
+          </div>
+        </main>
 
         {% if settings.CAS_SHOW_POWERED %}
         <footer class="mt-auto">

--- a/cas_server/templates/cas_server/base.html
+++ b/cas_server/templates/cas_server/base.html
@@ -2,92 +2,90 @@
 <html{% if LANGUAGE_CODE %} lang="{{LANGUAGE_CODE}}"{% endif %}>
     <head>
         <meta charset="utf-8">
-        <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge" /><![endif]-->
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>{% block title %}{% trans "Central Authentication Service"  %}{% endblock %}</title>
-        <link href="{{settings.CAS_COMPONENT_URLS.bootstrap3_css}}" rel="stylesheet">
-        <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-        <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-        <!--[if lt IE 9]>
-        <script src="{{settings.CAS_COMPONENT_URLS.html5shiv}}"></script>
-        <script src="{{settings.CAS_COMPONENT_URLS.respond}}"></script>
-        <![endif]-->
+        <link href="{{settings.CAS_COMPONENT_URLS.bootstrap4_css}}" rel="stylesheet" crossorigin="anonymous">
         {% if settings.CAS_FAVICON_URL %}<link rel="shortcut icon" href="{{settings.CAS_FAVICON_URL}}" />{% endif %}
         <link href="{% static "cas_server/styles.css" %}" rel="stylesheet">
     </head>
     <body>
-      <div id="wrap">
-        <div class="container">
+      <div class="cover-container d-flex w-100 h-100 p-3 mx-auto flex-column">
+        {% if auto_submit %}<noscript>{% endif %}
+        <header class="mb-auto">
+          <h1 id="app-name" class="text-center">
+            {% if settings.CAS_LOGO_URL %}<img src="{{settings.CAS_LOGO_URL}}" alt="cas-logo" />{% endif %}
+            {% trans "Central Authentication Service" %}
+          </h1>
+          {% for msg in CAS_INFO_RENDER %}
+            <div class="alert alert-{{msg.type}}{% if msg.discardable %} alert-dismissable{% endif %}">
+              {% if msg.discardable %}<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>{% endif %}
+              {{msg.message}}
+            </div>
+          {% endfor %}
+          {% if settings.CAS_NEW_VERSION_HTML_WARNING and upgrade_available %}
+            <div class="alert alert-info alert-dismissable">
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <p>{% blocktrans %}A new version of the application is available. This instance runs {{VERSION}} and the last version is {{LAST_VERSION}}. Please consider upgrading.{% endblocktrans %}</p>
+            </div>
+          {% endif %}
+        </header>
+        {% if auto_submit %}</noscript>{% endif %}
+
+        <div class="row justify-content-center">
+          <main class="card border-dark" style="max-width: 30rem;">
             {% if auto_submit %}<noscript>{% endif %}
-            <div class="row">
-              <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-                <h1 id="app-name">
-                    {% if settings.CAS_LOGO_URL %}<img src="{{settings.CAS_LOGO_URL}}" alt="cas-logo" />{% endif %}
-                    {% trans "Central Authentication Service" %}</h1>
-              </div>
+            <div class="card-header text-center">
+              {% block ante_messages %}{% endblock %}
             </div>
             {% if auto_submit %}</noscript>{% endif %}
-            <div class="row">
-            <div class="col-lg-3 col-md-3 col-sm-2 col-xs-12"></div>
-            <div class="col-lg-6 col-md-6 col-sm-8 col-xs-12">
-            {% if auto_submit %}<noscript>{% endif %}
-            {% for msg in CAS_INFO_RENDER %}
-              <div class="alert alert-{{msg.type}}{% if msg.discardable %} alert-dismissable{% endif %}">
-                {% if msg.discardable %}<button type="button" class="close" data-dismiss="alert" aria-hidden="true" id="info-{{msg.name}}">&#215;</button>{% endif %}
-                <p>{{msg.message}}</p>
-              </div>
-            {% endfor %}
-            {% if settings.CAS_NEW_VERSION_HTML_WARNING and upgrade_available %}
-              <div class="alert alert-info alert-dismissable">
-                <button type="button" class="close" data-dismiss="alert" aria-hidden="true" id="alert-version">&#215;</button>
-                <p>{% blocktrans %}A new version of the application is available. This instance runs {{VERSION}} and the last version is {{LAST_VERSION}}. Please consider upgrading.{% endblocktrans %}</p>
-              </div>
-            {% endif %}
-            {% block ante_messages %}{% endblock %}
-            {% for message in messages %}
-                <div {% spaceless %}
-                    {% if message.level == message_levels.DEBUG %}
-                        class="alert alert-warning"
-                    {% elif message.level == message_levels.INFO %}
-                        class="alert alert-info"
-                    {% elif message.level == message_levels.SUCCESS %}
-                        class="alert alert-success"
-                    {% elif message.level == message_levels.WARNING %}
-                        class="alert alert-warning"
-                    {% else %}
-                        class="alert alert-danger"
-                    {% endif %}
-                {% endspaceless %}>
-                    <p>{{message}}</p>
-                </div>
-            {% endfor %}
-            {% if auto_submit %}</noscript>{% endif %}
-            {% block content %}{% endblock %}
+            <div class="card-body">
+              {% for message in messages %}
+                  <div {% spaceless %}
+                      {% if message.level == message_levels.DEBUG %}
+                          class="alert alert-warning"
+                      {% elif message.level == message_levels.INFO %}
+                          class="alert alert-info"
+                      {% elif message.level == message_levels.SUCCESS %}
+                          class="alert alert-success"
+                      {% elif message.level == message_levels.WARNING %}
+                          class="alert alert-warning"
+                      {% else %}
+                          class="alert alert-danger"
+                      {% endif %}
+                  {% endspaceless %}>
+                      <p>{{message}}</p>
+                  </div>
+              {% endfor %}
+              {% block content %}{% endblock %}
             </div>
-            <div class="col-lg-3 col-md-3 col-sm-2 col-xs-0"></div>
-            </div>
-        </div> <!-- /container -->
+          </main>
+        </div>
+
+        {% if settings.CAS_SHOW_POWERED %}
+        <footer class="mt-auto">
+            <p class="text-center">
+              <a class="text-muted" href="https://pypi.org/project/django-cas-server/">
+                django-cas-server powered
+              </a>
+            </p>
+        </footer>
+        {% endif %}
       </div>
-      <div style="clear: both;"></div>
-      {% if settings.CAS_SHOW_POWERED %}
-      <div id="footer">
-          <p><a class="text-muted" href="https://pypi.org/project/django-cas-server/">django-cas-server powered</a></p>
-      </div>
-      {% endif %}
-      <script src="{{settings.CAS_COMPONENT_URLS.jquery}}"></script>
-      <script src="{{settings.CAS_COMPONENT_URLS.bootstrap3_js}}"></script>
+
+      <script src="{{settings.CAS_COMPONENT_URLS.jquery}}" crossorigin="anonymous"></script>
+      <script src="{{settings.CAS_COMPONENT_URLS.bootstrap4_js}}" crossorigin="anonymous"></script>
       <script src="{% static "cas_server/functions.js" %}"></script>
       <script type="text/javascript">
-{% if settings.CAS_NEW_VERSION_HTML_WARNING and upgrade_available %}
-discard_and_remember("#alert-version", "cas-alert-version", "{{LAST_VERSION}}");
-{% endif %}
-{% for msg in CAS_INFO_RENDER %}
-{% if msg.discardable %}
-discard_and_remember("#info-{{msg.name}}", "cas-info-{{msg.name}}", "{{msg.hash}}");
-{% endif %}
-{% endfor %}
-{% block javascript_inline %}{% endblock %}
-</script>
+      {% if settings.CAS_NEW_VERSION_HTML_WARNING and upgrade_available %}
+      discard_and_remember("#alert-version", "cas-alert-version", "{{LAST_VERSION}}");
+      {% endif %}
+      {% for msg in CAS_INFO_RENDER %}
+      {% if msg.discardable %}
+      discard_and_remember("#info-{{msg.name}}", "cas-info-{{msg.name}}", "{{msg.hash}}");
+      {% endif %}
+      {% endfor %}
+      {% block javascript_inline %}{% endblock %}
+      </script>
       {% block javascript %}{% endblock %}
     </body>
 </html>

--- a/cas_server/templates/cas_server/form.html
+++ b/cas_server/templates/cas_server/form.html
@@ -2,7 +2,7 @@
 
 {% for error in form.non_field_errors %}
   <div class="alert alert-danger alert-dismissable">
-    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     {{error}}
   </div>
 {% endfor %}

--- a/cas_server/templates/cas_server/form.html
+++ b/cas_server/templates/cas_server/form.html
@@ -1,10 +1,12 @@
 {% load cas_server %}
+
 {% for error in form.non_field_errors %}
-<div class="alert alert-danger alert-dismissable">
-  <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
-  {{error}}
-</div>
+  <div class="alert alert-danger alert-dismissable">
+    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&#215;</button>
+    {{error}}
+  </div>
 {% endfor %}
+
 {% for field in form %}{% if not field|is_hidden %}
 <div class="form-group
   {% if not form.non_field_errors %}
@@ -14,9 +16,14 @@
   {% endif %}"
 >{% spaceless %}
   {% if field|is_checkbox %}
-    <div class="checkbox"><label for="{{field.auto_id}}">{{field}}{{field.label}}</label></div>
+    <div class="form-check">
+      <span class="form-check-input mt-0">{{field}}</span>
+      <label class="form-check-label" for="{{field.auto_id}}">
+        {{field.label}}
+      </label>
+    </div>
   {% else %}
-    <label class="control-label" for="{{field.auto_id}}">{{field.label}}</label>
+    <label class="control-label" for="{{field.auto_id}}">{{field.label|capfirst}}</label>
     {{field}}
   {% endif %}
   {% for error in field.errors %}

--- a/cas_server/templates/cas_server/login.html
+++ b/cas_server/templates/cas_server/login.html
@@ -2,30 +2,32 @@
 {% load i18n %}
 
 {% block ante_messages %}
-    {% if auto_submit %}<noscript>{% endif %}
+  {% if auto_submit %}<noscript>{% endif %}
+  <div class="card-header text-center">
     <h2 class="form-signin-heading">{% trans "Please log in" %}</h2>
-    {% if auto_submit %}</noscript>{% endif %}
+  </div>
+  {% if auto_submit %}</noscript>{% endif %}
 {% endblock %}
 
 {% block content %}
-    <form class="form-signin" method="post" id="login_form"{% if post_url %} action="{{post_url}}"{% endif %}>
-        {% csrf_token %}
-        {% include "cas_server/form.html" %}
-        {% if auto_submit %}<noscript>{% endif %}
-        <button class="btn btn-primary btn-block btn-lg" type="submit">{% trans "Login" %}</button>
-        {% if auto_submit %}</noscript>{% endif %}
-    </form>
+  <form class="form-signin" method="post" id="login_form"{% if post_url %} action="{{post_url}}"{% endif %}>
+    {% csrf_token %}
+    {% include "cas_server/form.html" %}
+    {% if auto_submit %}<noscript>{% endif %}
+    <button class="btn btn-primary btn-block btn-lg" type="submit">{% trans "Login" %}</button>
+    {% if auto_submit %}</noscript>{% endif %}
+  </form>
 {% endblock %}
 
 {% block javascript_inline %}
 jQuery(function( $ ){
-    $("#id_warn").click(function(e){
-        if($("#id_warn").is(':checked')){
-            createCookie("warn", "on", 10 * 365);
-        } else {
-            eraseCookie("warn");
-        }
-    });
+  $("#id_warn").click(function(e){
+    if($("#id_warn").is(':checked')){
+      createCookie("warn", "on", 10 * 365);
+    } else {
+      eraseCookie("warn");
+    }
+  });
 });
 {% if auto_submit %}document.getElementById('login_form').submit(); // SUBMIT FORM{% endif %}
 {% endblock %}

--- a/cas_server/templates/cas_server/login.html
+++ b/cas_server/templates/cas_server/login.html
@@ -2,19 +2,21 @@
 {% load i18n %}
 
 {% block ante_messages %}
-{% if auto_submit %}<noscript>{% endif %}
-<h2 class="form-signin-heading">{% trans "Please log in" %}</h2>
-{% if auto_submit %}</noscript>{% endif %}
+    {% if auto_submit %}<noscript>{% endif %}
+    <h2 class="form-signin-heading">{% trans "Please log in" %}</h2>
+    {% if auto_submit %}</noscript>{% endif %}
 {% endblock %}
+
 {% block content %}
-<form class="form-signin" method="post" id="login_form"{% if post_url %} action="{{post_url}}"{% endif %}>
-  {% csrf_token %}
-  {% include "cas_server/form.html" %}
-  {% if auto_submit %}<noscript>{% endif %}
-  <button class="btn btn-primary btn-block btn-lg" type="submit">{% trans "Login" %}</button>
-  {% if auto_submit %}</noscript>{% endif %}
-</form>
+    <form class="form-signin" method="post" id="login_form"{% if post_url %} action="{{post_url}}"{% endif %}>
+        {% csrf_token %}
+        {% include "cas_server/form.html" %}
+        {% if auto_submit %}<noscript>{% endif %}
+        <button class="btn btn-primary btn-block btn-lg" type="submit">{% trans "Login" %}</button>
+        {% if auto_submit %}</noscript>{% endif %}
+    </form>
 {% endblock %}
+
 {% block javascript_inline %}
 jQuery(function( $ ){
     $("#id_warn").click(function(e){
@@ -24,7 +26,6 @@ jQuery(function( $ ){
             eraseCookie("warn");
         }
     });
-});{% if auto_submit %}
-document.getElementById('login_form').submit(); // SUBMIT FORM{% endif %}
+});
+{% if auto_submit %}document.getElementById('login_form').submit(); // SUBMIT FORM{% endif %}
 {% endblock %}
-


### PR DESCRIPTION
This PR upgrades templates towards Bootstrap 4.4 and make some style changes. This introduces CSS helpers reducing the amount of CSS code needed for this app.

The style was written with the idea of being able to add a background image easily.

This PR drops the support of Internet Explorer 8.
The flexbox (to put the footer nicely at the bottom) is compatible with only IE10+ : <https://caniuse.com/#feat=flexbox>.

![screenshot](https://user-images.githubusercontent.com/2663216/71627951-d7756b80-2bf5-11ea-9dd9-bc15a7621ed1.png)
