### PR TITLE
Fix CRYPT-DES hash method for LDAP

### DIFF
--- a/cas_server/utils.py
+++ b/cas_server/utils.py
@@ -593,7 +593,9 @@ class LdapHashUserPassword(object):
         if scheme in cls.schemes_nosalt:
             return b""
         elif scheme == b'{CRYPT}':
-            return b'$'.join(hashed_passord.split(b'$', 3)[:-1])[len(scheme):]
+            if b'$' in hashed_passord:
+                return b'$'.join(hashed_passord.split(b'$', 3)[:-1])[len(scheme):]
+            return hashed_passord.split(b'}', 1)[-1]
         else:
             try:
                 hashed_passord = base64.b64decode(hashed_passord[len(scheme):])


### PR DESCRIPTION
Fixes #53 

The LDAP-formatted passwords using [Crypt encoding](https://en.wikipedia.org/wiki/Crypt_(C)) can be hashed in many ways, inlcuding the old and deprecated DES and BSDi methods.

The usual formatting for Crypt method consists in
```
  $method$salt$pass_hash
```
but those two deprecated methods are not encoded this way, and `get_salt` would fail on those, yielding Error 500.