### PR TITLE
Service URL: keep blank GET arguments

### DIFF
--- a/cas_server/utils.py
+++ b/cas_server/utils.py
@@ -258,7 +258,7 @@ def update_url(url, params):
             value = value.encode('utf-8')
         params[key] = value
     url_parts = list(urlparse(url))
-    query = dict(parse_qsl(url_parts[4]))
+    query = dict(parse_qsl(url_parts[4], keep_blank_values=True))
     query.update(params)
     # make the params order deterministic
     query = list(query.items())


### PR DESCRIPTION
When a service URL contains GET arguments with no associated value, eg.
```
http://example.com/?foo=a&bar
```

only the arguments with value are kept, yielding to a redirection to

```
http://example.com/?foo=a&ticket=<TICKET>
```

losing `bar` in the process.

This is due to the default behaviour of `urllib.parse.parse_qsl`, which discards such arguments without value.