### PR TITLE
[docs] Replace calls to add_description_unit

### DIFF
--- a/docs/_ext/djangodocs.py
+++ b/docs/_ext/djangodocs.py
@@ -41,7 +41,7 @@ def setup(app):
         rolename="lookup",
         indextemplate="pair: %s; field lookup type",
     )
-    app.add_description_unit(
+    app.add_object_type(
         directivename="django-admin",
         rolename="djadmin",
         indextemplate="pair: %s; django-admin command",


### PR DESCRIPTION
As of Sphinx 2.4, the deprecated add_description_unit function has been
removed. As a result, the docs no longer build when using Sphinx 2.4.
Replacing add_description_unit with add_object_type corrects this.