### PR TITLE
Allow more complex LDAP user queries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -436,7 +436,7 @@ Only useful if you are using the ldap authentication backend:
 * ``CAS_LDAP_PASSWORD``: Password for connecting to the LDAP server.
 * ``CAS_LDAP_BASE_DN``: LDAP search base DN, for example ``"ou=data,dc=crans,dc=org"``.
 * ``CAS_LDAP_USER_QUERY``: Search filter for searching user by username. User entered usernames are
-  escaped using ``ldap3.utils.conv.escape_bytes``. The default is ``"(uid=%s)"``
+  escaped using ``ldap3.utils.conv.escape_bytes``. The default is ``"(uid=%(username)s)"``
 * ``CAS_LDAP_USERNAME_ATTR``: Attribute used for user's usernames. The default is ``"uid"``
 * ``CAS_LDAP_PASSWORD_ATTR``: Attribute used for user's passwords. The default is ``"userPassword"``
 * ``CAS_LDAP_PASSWORD_CHECK``: The method used to check the user password. Must be one of the following:

--- a/cas_server/auth.py
+++ b/cas_server/auth.py
@@ -296,7 +296,7 @@ class LdapAuthUser(DBAuthUser):  # pragma: no cover
                 conn = self.get_conn()
                 if conn.search(
                     settings.CAS_LDAP_BASE_DN,
-                    settings.CAS_LDAP_USER_QUERY % ldap3.utils.conv.escape_bytes(username),
+                    settings.CAS_LDAP_USER_QUERY % {'username': ldap3.utils.conv.escape_bytes(username)},
                     attributes=ldap3.ALL_ATTRIBUTES
                 ) and len(conn.entries) == 1:
                     # try the new ldap3>=2 API
@@ -345,7 +345,7 @@ class LdapAuthUser(DBAuthUser):  # pragma: no cover
                     # fetch the user attribute
                     if conn.search(
                         settings.CAS_LDAP_BASE_DN,
-                        settings.CAS_LDAP_USER_QUERY % ldap3.utils.conv.escape_bytes(self.username),
+                        settings.CAS_LDAP_USER_QUERY % {'username': ldap3.utils.conv.escape_bytes(self.username)},
                         attributes=ldap3.ALL_ATTRIBUTES
                     ) and len(conn.entries) == 1:
                         # try the ldap3>=2 API

--- a/cas_server/default_settings.py
+++ b/cas_server/default_settings.py
@@ -158,7 +158,7 @@ CAS_LDAP_PASSWORD = None
 CAS_LDAP_BASE_DN = None
 #: LDAP search filter for searching user by username. User inputed usernames are escaped using
 #: :func:`ldap3.utils.conv.escape_bytes`.
-CAS_LDAP_USER_QUERY = "(uid=%s)"
+CAS_LDAP_USER_QUERY = "(uid=%(username)s)"
 #: LDAP attribute used for users usernames
 CAS_LDAP_USERNAME_ATTR = "uid"
 #: LDAP attribute used for users passwords


### PR DESCRIPTION
As it stands, LDAP queries are limited to simple filters, since only one parameter can only be used the way formatting is done in auth.py.
This PR rewrites the two culprit lines to allow a user query such as `CAS_LDAP_USER_QUERY="(&(objectclass=*)(|(uid=%(username)s)(mail=%(username)s)))"` plus the default value and doc line.