### PR TITLE
Update to version 3.0.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,4 +15,3 @@ exclude_lines =
     def __str__
     raise AssertionError
     raise NotImplementedError
-    if six.PY3:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -52,20 +52,25 @@ jobs:
             env: "py38-django22"
           # Debian bullseye
           - python: "3.9"
-            env: py39-django22
+            env: "py39-django22"
           # Ubuntu jammy
           - python: "3.10"
             env: "py310-django32"
           # Debian bookworm
           - python: "3.11"
-            env: py311-django32
+            env: "py311-django32"
+          # Ubuntu noble
+          - python: "3.12"
+            env: "py312-django42"
           # Django additional supported version
-          - python: "3.9"
-            env: py39-django42
           - python: "3.10"
-            env: py310-django42
+            env: "py310-django52"
           - python: "3.11"
-            env: py311-django42
+            env: "py311-django52"
+          - python: "3.12"
+            env: "py312-django52"
+          - python: "3.13"
+            env: "py313-django52"
     steps:
       - uses: actions/checkout@v3
       - if: matrix.arch != 'amd64'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "ppc64le"]
+        arch: ["amd64"]
         tox:
           # REHL 7 support and Ubuntu bionic
           - python: "3.6"
@@ -53,15 +53,9 @@ jobs:
           # Debian bullseye
           - python: "3.9"
             env: "py39-django22"
-          # Ubuntu jammy
-          - python: "3.10"
-            env: "py310-django32"
           # Debian bookworm
           - python: "3.11"
             env: "py311-django32"
-          # Ubuntu noble
-          - python: "3.12"
-            env: "py312-django42"
           # Django additional supported version
           - python: "3.10"
             env: "py310-django52"
@@ -71,6 +65,30 @@ jobs:
             env: "py312-django52"
           - python: "3.13"
             env: "py313-django52"
+    steps:
+      - uses: actions/checkout@v3
+      - if: matrix.arch != 'amd64'
+        name: "Install docker multiarch support"
+        run: |
+          sudo docker run --rm --privileged tonistiigi/binfmt --install ${{ matrix.arch }}
+          sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
+      - name: "Check docker arch ${{ matrix.arch }} support"
+        run: sudo docker run --platform linux/${{ matrix.arch }} --rm ${{ matrix.arch }}/python:${{ matrix.tox.python }} /bin/bash -c "echo -n \"Running with arch \"; uname -m;"
+      - name: "Run tests on arch ${{ matrix.arch }}"
+        run: sudo docker run --platform linux/${{ matrix.arch }} --rm -v $(pwd):$(pwd) ${{ matrix.arch }}/python:${{ matrix.tox.python }} /bin/bash -c "cd $(pwd); uname -m; pip install tox; tox -e ${{ matrix.tox.env }}"
+  tests-ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["amd64", "ppc64le"]
+        tox:
+          # Ubuntu jammy
+          - python: "3.10"
+            env: "py310-django32"
+          # Ubuntu noble
+          - python: "3.12"
+            env: "py312-django42"
     steps:
       - uses: actions/checkout@v3
       - if: matrix.arch != 'amd64'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -76,8 +76,7 @@ jobs:
       - if: matrix.arch != 'amd64'
         name: "Install docker multiarch support"
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y qemu qemu-user-static
+          sudo docker run --rm --privileged tonistiigi/binfmt --install ${{ matrix.arch }}
           sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
       - name: "Check docker arch ${{ matrix.arch }} support"
         run: sudo docker run --platform linux/${{ matrix.arch }} --rm ${{ matrix.arch }}/python:${{ matrix.tox.python }} /bin/bash -c "echo -n \"Running with arch \"; uname -m;"

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ manage.py
 coverage.xml
 docs/_build/
 docs/django.inv
+docs/python.inv
 
 .tox
 test_venv

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,34 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+formats:
+   - pdf
+   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 .. contents:: Table of Contents
    :depth: 2
 
+Unreleased
+==========
+
+Changed
+-------
+
+* Allow more complex LDAP user queries
+
+Deprecated
+----------
+
+* Using %s in your CAS_LDAP_USER_QUERY is deprecated.
+  Please upgrade your config to use %(username)s instead
+
 v2.1.0 - 2024-08-18
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Removed
 * Drop support for Django 4.0 and 4.1 as it reached end of life.
 * Removed six transitional dependency. This break for sure
   python 2.7 if it was still working
+* Remove pytest-runner as it's deprecated
 
 Deprecated
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Removed
 -------
 
 * Drop support for Django 4.0 and 4.1 as it reached end of life.
+* Removed six transitional dependency. This break for sure
+  python 2.7 if it was still working
 
 Deprecated
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 .. contents:: Table of Contents
    :depth: 2
 
-Unreleased
-==========
+v3.0.0 - 2025-04-21
+===================
 
 Added
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 -------
 
 * Allow more complex LDAP user queries
+* Prefer local inventory for intersphinx
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,16 +9,27 @@ All notable changes to this project will be documented in this file.
 Unreleased
 ==========
 
+Added
+-----
+
+* Support for Django 5.2
+
 Changed
 -------
 
 * Allow more complex LDAP user queries
+
+Removed
+-------
+
+* Drop support for Django 4.0 and 4.1 as it reached end of life.
 
 Deprecated
 ----------
 
 * Using %s in your CAS_LDAP_USER_QUERY is deprecated.
   Please upgrade your config to use %(username)s instead
+
 
 v2.1.0 - 2024-08-18
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 -----
 
 * Support for Django 5.2
+* Support for Kerberos/GSSAPI authentication
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Fix
 * datetime.datetime.utcnow() is deprecated and scheduled for removal.
   Use timezone-aware objects to represent datetimes in UTC:
   datetime.datetime.now(datetime.timezone.UTC).
+* Skip tests using crypt module if module is not available
 
 
 v2.1.0 - 2024-08-18

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,13 @@ Deprecated
 * Using %s in your CAS_LDAP_USER_QUERY is deprecated.
   Please upgrade your config to use %(username)s instead
 
+Fix
+---
+
+* datetime.datetime.utcnow() is deprecated and scheduled for removal.
+  Use timezone-aware objects to represent datetimes in UTC:
+  datetime.datetime.now(datetime.timezone.UTC).
+
 
 v2.1.0 - 2024-08-18
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
 
 * Allow more complex LDAP user queries
 * Prefer local inventory for intersphinx
+* Replace mock test module with the one from unittest
 
 Removed
 -------

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean_coverage:
 clean_tild_backup:
 	find ./ -name '*~' -delete
 clean_docs:
-	rm -rf docs/_build/ docs/django.inv
+	rm -rf docs/_build/ docs/django.inv docs/python.inv
 clean_eggs:
 	rm -rf .eggs/
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ dist:
 
 test_venv/bin/python:
 	python3 -m venv test_venv
-	test_venv/bin/pip install -U --requirement requirements-dev.txt 'Django>=4.2,<4.3'
+	test_venv/bin/pip install -U --requirement requirements-dev.txt 'Django>=5.2,<5.3'
 
 test_venv/cas/manage.py: test_venv
 	mkdir -p test_venv/cas

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ run_tests: test_venv
 	rm htmlcov/coverage_html.js  # I am really pissed off by those keybord shortcuts
 
 test_venv/bin/sphinx-build: test_venv
-	test_venv/bin/pip install Sphinx sphinx_rtd_theme
+	test_venv/bin/pip install -r docs/requirements.txt
 
 docs: test_venv/bin/sphinx-build
 	bash -c "source test_venv/bin/activate; cd docs; make html"

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Features
 * Possibility to rename/rewrite attributes per service
 * Possibility to require some attribute values per service
 * Federated mode between multiple CAS
-* Supports Django 1.11, 2.2, 3.2, 4.2
+* Supports Django 1.11, 2.2, 3.2, 4.2, 5.2
 * Supports Python 3.6+
 
 Dependencies

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Additionally, depending on the `Authentication backend`_ you plan to use, you ma
 python packages:
 
 * ldap3
+* gssapi
 * psycopg2
 * mysql-python
 
@@ -67,6 +68,8 @@ packages on your system using pip3 inside a virtualenv as described in the `Inst
 | psycopg2         | python3-psycopg2         |
 +------------------+--------------------------+
 | mysql-python     | python3-mysqldb          |
++------------------+--------------------------+
+| gssapi           | python3-gssapi           |
 +------------------+--------------------------+
 
 Installation
@@ -253,6 +256,17 @@ Authentication settings
   ``cas_server.auth.AuthUser``. The default is ``"cas_server.auth.DjangoAuthUser"``
   Available classes bundled with ``django-cas-server`` are listed below in the
   `Authentication backend`_ section.
+
+* ``CAS_AUTH_GSSAPI_ENABLE``: Activate Kerberos authentication (not compatible with
+  federate mode or auth class requiring access to the user credential to retrieve
+  user attributes).
+  See https://web.mit.edu/kerberos/krb5-1.13/doc/admin/env_variables.html for environment
+  variables allowing to configure the underlying GSSAPI C library.
+  Username retrieved form kerberos auth MUST match username used by the  ``CAS_AUTH_CLASS``
+  The default is ``False``
+
+* ``CAS_AUTH_GSSAPI_SERVICENAME``: Service Principal Name to use for Kerberos authentication
+  (must be available in the server keytab).
 
 * ``SESSION_COOKIE_AGE``: This is a django setting. Here, it controls the delay in seconds after
   which inactive users are logged out. The default is ``1209600`` (2 weeks). You probably should

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,6 @@ Dependencies
 * requests >= 2.4
 * requests_futures >= 0.9.5
 * lxml >= 3.4
-* six >= 1.8
 
 Minimal version of package dependencies are just indicative and means that ``django-cas-server`` has
 been tested with it. Previous versions of dependencies may or may not work.
@@ -51,7 +50,6 @@ them on debian like systems and centos like systems.
 You should try as much as possible to use system packages as they are automatically updated when
 you update your system. You can then install Not Available (N/A)
 packages on your system using pip3 inside a virtualenv as described in the `Installation`_ section.
-For use with python2, just replace python3(6) in the table by python.
 
 +------------------+--------------------------+---------------------+
 | python package   | debian like systems      | centos like systems |
@@ -63,8 +61,6 @@ For use with python2, just replace python3(6) in the table by python.
 | requests_futures | python3-requests-futures | N/A                 |
 +------------------+--------------------------+---------------------+
 | lxml             | python3-lxml             | python36-lxml       |
-+------------------+--------------------------+---------------------+
-| six              | python3-six              | python36-six        |
 +------------------+--------------------------+---------------------+
 | ldap3            | python3-ldap3            | python36-ldap3      |
 +------------------+--------------------------+---------------------+
@@ -84,14 +80,14 @@ The recommended installation mode is to use a virtualenv with ``--system-site-pa
 
    On debian like systems::
 
-    $ sudo apt-get install python3-django python3-requests python3-six python3-lxml python3-requests-futures
+    $ sudo apt-get install python3-django python3-requests python3-lxml python3-requests-futures
 
    On debian jessie, you can use the version of python-django available in the
    `backports <https://backports.debian.org/Instructions/>`_.
 
    On centos like systems with epel enabled::
 
-    $ sudo yum install python36-django python36-requests python36-six python36-lxml
+    $ sudo yum install python36-django python36-requests python36-lxml
 
 3. Create a virtualenv::
 

--- a/README.rst
+++ b/README.rst
@@ -46,28 +46,28 @@ python packages:
 
 
 Here is a table with the name of python packages and the corresponding packages providing
-them on debian like systems and centos like systems.
+them on debian like systems.
 You should try as much as possible to use system packages as they are automatically updated when
 you update your system. You can then install Not Available (N/A)
 packages on your system using pip3 inside a virtualenv as described in the `Installation`_ section.
 
-+------------------+--------------------------+---------------------+
-| python package   | debian like systems      | centos like systems |
-+==================+==========================+=====================+
-| Django           | python3-django           | python36-django     |
-+------------------+--------------------------+---------------------+
-| requests         | python3-requests         | python36-requests   |
-+------------------+--------------------------+---------------------+
-| requests_futures | python3-requests-futures | N/A                 |
-+------------------+--------------------------+---------------------+
-| lxml             | python3-lxml             | python36-lxml       |
-+------------------+--------------------------+---------------------+
-| ldap3            | python3-ldap3            | python36-ldap3      |
-+------------------+--------------------------+---------------------+
-| psycopg2         | python3-psycopg2         | python36-psycopg2   |
-+------------------+--------------------------+---------------------+
-| mysql-python     | python3-mysqldb          | python36-mysql      |
-+------------------+--------------------------+---------------------+
++------------------+--------------------------+
+| python package   | debian like systems      |
++==================+==========================+
+| Django           | python3-django           |
++------------------+--------------------------+
+| requests         | python3-requests         |
++------------------+--------------------------+
+| requests_futures | python3-requests-futures |
++------------------+--------------------------+
+| lxml             | python3-lxml             |
++------------------+--------------------------+
+| ldap3            | python3-ldap3            |
++------------------+--------------------------+
+| psycopg2         | python3-psycopg2         |
++------------------+--------------------------+
+| mysql-python     | python3-mysqldb          |
++------------------+--------------------------+
 
 Installation
 ============
@@ -81,13 +81,6 @@ The recommended installation mode is to use a virtualenv with ``--system-site-pa
    On debian like systems::
 
     $ sudo apt-get install python3-django python3-requests python3-lxml python3-requests-futures
-
-   On debian jessie, you can use the version of python-django available in the
-   `backports <https://backports.debian.org/Instructions/>`_.
-
-   On centos like systems with epel enabled::
-
-    $ sudo yum install python36-django python36-requests python36-lxml
 
 3. Create a virtualenv::
 

--- a/README.rst
+++ b/README.rst
@@ -436,7 +436,7 @@ Only useful if you are using the ldap authentication backend:
 * ``CAS_LDAP_PASSWORD``: Password for connecting to the LDAP server.
 * ``CAS_LDAP_BASE_DN``: LDAP search base DN, for example ``"ou=data,dc=crans,dc=org"``.
 * ``CAS_LDAP_USER_QUERY``: Search filter for searching user by username. User entered usernames are
-  escaped using ``ldap3.utils.conv.escape_bytes``. The default is ``"(uid=%s)"``
+  escaped using ``ldap3.utils.conv.escape_bytes``. The default is ``"(uid=%(username)s)"``
 * ``CAS_LDAP_USERNAME_ATTR``: Attribute used for user's usernames. The default is ``"uid"``
 * ``CAS_LDAP_PASSWORD_ATTR``: Attribute used for user's passwords. The default is ``"userPassword"``
 * ``CAS_LDAP_PASSWORD_CHECK``: The method used to check the user password. Must be one of the following:

--- a/cas_server/__init__.py
+++ b/cas_server/__init__.py
@@ -7,7 +7,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2024 Valentin Samir
 """A django CAS server application"""
 try:
     import django

--- a/cas_server/__init__.py
+++ b/cas_server/__init__.py
@@ -7,7 +7,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2024 Valentin Samir
+# (c) 2015-2025 Valentin Samir
 """A django CAS server application"""
 try:
     import django
@@ -15,7 +15,7 @@ except ModuleNotFoundError:
     django = None
 
 #: version of the application
-VERSION = '2.1.0'
+VERSION = '3.0.0'
 
 if django is None or django.VERSION < (3, 2):
     #: path the the application configuration class

--- a/cas_server/admin.py
+++ b/cas_server/admin.py
@@ -7,7 +7,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2024 Valentin Samir
 """module for the admin interface of the app"""
 from .default_settings import settings
 

--- a/cas_server/apps.py
+++ b/cas_server/apps.py
@@ -7,7 +7,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2020 Valentin Samir
 """django config module"""
 from django.apps import AppConfig
 

--- a/cas_server/auth.py
+++ b/cas_server/auth.py
@@ -17,7 +17,6 @@ from django.db import connections, DatabaseError
 
 import warnings
 from datetime import timedelta
-from six.moves import range
 try:  # pragma: no cover
     import MySQLdb
     import MySQLdb.cursors

--- a/cas_server/auth.py
+++ b/cas_server/auth.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2025 Valentin Samir
 """Some authentication classes for the CAS"""
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/cas_server/auth.py
+++ b/cas_server/auth.py
@@ -296,7 +296,7 @@ class LdapAuthUser(DBAuthUser):  # pragma: no cover
                 conn = self.get_conn()
                 if conn.search(
                     settings.CAS_LDAP_BASE_DN,
-                    settings.CAS_LDAP_USER_QUERY % ldap3.utils.conv.escape_bytes(username),
+                    settings.CAS_LDAP_USER_QUERY % {'username': ldap3.utils.conv.escape_bytes(username)},
                     attributes=ldap3.ALL_ATTRIBUTES
                 ) and len(conn.entries) == 1:
                     # try the new ldap3>=2 API
@@ -345,7 +345,7 @@ class LdapAuthUser(DBAuthUser):  # pragma: no cover
                     # fetch the user attribute
                     if conn.search(
                         settings.CAS_LDAP_BASE_DN,
-                        settings.CAS_LDAP_USER_QUERY % ldap3.utils.conv.escape_bytes(self.username),
+                        settings.CAS_LDAP_USER_QUERY % {'username': ldap3.utils.conv.escape_bytes(self.username)},
                         attributes=ldap3.ALL_ATTRIBUTES
                     ) and len(conn.entries) == 1:
                         # try the ldap3>=2 API

--- a/cas_server/cas.py
+++ b/cas_server/cas.py
@@ -22,10 +22,9 @@
 # at commit ec1f2d4779625229398547b9234d0e9e874a2c9a
 # some modifications have been made to be unicode coherent between python2 and python2
 
-import six
-from six.moves.urllib import parse as urllib_parse
-from six.moves.urllib import request as urllib_request
-from six.moves.urllib.request import Request
+import urllib.parse as urllib_parse
+import urllib.request as urllib_request
+from urllib.request import Request
 from uuid import uuid4
 import datetime
 
@@ -37,7 +36,7 @@ class CASError(ValueError):
 class ReturnUnicode(object):
     @staticmethod
     def u(string, charset):
-        if not isinstance(string, six.text_type):
+        if not isinstance(string, str):
             return string.decode(charset)
         else:
             return string

--- a/cas_server/default_settings.py
+++ b/cas_server/default_settings.py
@@ -64,6 +64,14 @@ CAS_REDIRECT_TO_LOGIN_AFTER_LOGOUT = False
 
 #: A dotted path to a class or a class implementing cas_server.auth.AuthUser.
 CAS_AUTH_CLASS = 'cas_server.auth.DjangoAuthUser'
+#: Activate Kerberos authentication (not compatible with federate mode or auth class
+#: requiring access to the user credential to retrieve user attributes).
+#: See https://web.mit.edu/kerberos/krb5-1.13/doc/admin/env_variables.html
+#: for environment variables allowing to configure the underlying GSSAPI C library
+#: Username retrieved form kerberos auth MUST match username used by the  ``CAS_AUTH_CLASS``
+CAS_AUTH_GSSAPI_ENABLE = False
+#: SPN to use for Kerberos authentication (must be available in the loaded keytab)
+CAS_AUTH_GSSAPI_SERVICENAME = "host/myhost.example.com@AD.EXAMPLE.COM"
 #: Path to certificate authorities file. Usually on linux the local CAs are in
 #: /etc/ssl/certs/ca-certificates.crt. ``True`` tell requests to use its internal certificat
 #: authorities.

--- a/cas_server/default_settings.py
+++ b/cas_server/default_settings.py
@@ -158,7 +158,7 @@ CAS_LDAP_PASSWORD = None
 CAS_LDAP_BASE_DN = None
 #: LDAP search filter for searching user by username. User inputed usernames are escaped using
 #: :func:`ldap3.utils.conv.escape_bytes`.
-CAS_LDAP_USER_QUERY = "(uid=%s)"
+CAS_LDAP_USER_QUERY = "(uid=%(username)s)"
 #: LDAP attribute used for users usernames
 CAS_LDAP_USERNAME_ATTR = "uid"
 #: LDAP attribute used for users passwords

--- a/cas_server/default_settings.py
+++ b/cas_server/default_settings.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2025 Valentin Samir
 """Default values for the app's settings"""
 from django.conf import settings
 from django.templatetags.static import static

--- a/cas_server/federate.py
+++ b/cas_server/federate.py
@@ -17,7 +17,7 @@ from .cas import CASClient
 from .models import FederatedUser, FederateSLO, User
 
 import logging
-from six.moves import urllib
+import urllib
 
 #: logger facility
 logger = logging.getLogger(__name__)

--- a/cas_server/federate.py
+++ b/cas_server/federate.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2025 Valentin Samir
 """federated mode helper classes"""
 from .default_settings import SessionStore
 from django.db import IntegrityError

--- a/cas_server/forms.py
+++ b/cas_server/forms.py
@@ -7,7 +7,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2020 Valentin Samir
 """forms for the app"""
 from .default_settings import settings
 

--- a/cas_server/management/commands/cas_clean_federate.py
+++ b/cas_server/management/commands/cas_clean_federate.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2020 Valentin Samir
 from django.core.management.base import BaseCommand
 
 from ... import models

--- a/cas_server/management/commands/cas_clean_sessions.py
+++ b/cas_server/management/commands/cas_clean_sessions.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2020 Valentin Samir
 """Clean deleted sessions management command"""
 from django.core.management.base import BaseCommand
 

--- a/cas_server/management/commands/cas_clean_tickets.py
+++ b/cas_server/management/commands/cas_clean_tickets.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2020 Valentin Samir
 """Clean old trickets management command"""
 from django.core.management.base import BaseCommand
 

--- a/cas_server/models.py
+++ b/cas_server/models.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2021 Valentin Samir
 """models for the app"""
 from .default_settings import settings, SessionStore
 

--- a/cas_server/tests/mixin.py
+++ b/cas_server/tests/mixin.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2019 Valentin Samir
 """Some mixin classes for tests"""
 from cas_server.default_settings import settings
 from django.utils import timezone

--- a/cas_server/tests/test_federate.py
+++ b/cas_server/tests/test_federate.py
@@ -10,14 +10,14 @@
 #
 # (c) 2016 Valentin Samir
 """tests for the CAS federate mode"""
+import importlib
+
 from cas_server import default_settings
 from cas_server.default_settings import settings
 
 import django
 from django.test import TestCase, Client
 from django.test.utils import override_settings
-
-from six.moves import reload_module
 
 from cas_server import utils, models
 from cas_server.tests.mixin import BaseServicePattern, CanLogin, FederatedIendityProviderModel
@@ -49,7 +49,7 @@ class FederateAuthLoginLogoutTestCase(
     def test_default_settings(self):
         """default settings should populated some default variable then CAS_FEDERATE is True"""
         del settings.CAS_AUTH_CLASS
-        reload_module(default_settings)
+        importlib.reload(default_settings)
         self.assertEqual(settings.CAS_AUTH_CLASS, "cas_server.auth.CASFederateAuth")
 
     def test_login_get_provider(self):

--- a/cas_server/tests/test_federate.py
+++ b/cas_server/tests/test_federate.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2025 Valentin Samir
 """tests for the CAS federate mode"""
 import importlib
 

--- a/cas_server/tests/test_models.py
+++ b/cas_server/tests/test_models.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-205 Valentin Samir
 """Tests module for models"""
 from cas_server.default_settings import settings
 

--- a/cas_server/tests/test_models.py
+++ b/cas_server/tests/test_models.py
@@ -18,7 +18,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from django.core import mail
 
-import mock
+from unittest import mock
 from datetime import timedelta
 from importlib import import_module
 

--- a/cas_server/tests/test_utils.py
+++ b/cas_server/tests/test_utils.py
@@ -88,7 +88,7 @@ class CheckPasswordCase(TestCase):
         with self.assertRaises(ValueError):
             utils.check_password("crypt", self.password1, b"$truc$s$dsdsd", "utf8")
 
-    @unittest.skipIf(sys.version_info >= (3,13), "crypt module removed from python 3.13")
+    @unittest.skipIf(sys.version_info >= (3, 13), "crypt module removed from python 3.13")
     def test_ldap_password_valid(self):
         """test the ldap auth method with all the schemes"""
         salt = b"UVVAQvrMyXMF3FF3"
@@ -116,7 +116,7 @@ class CheckPasswordCase(TestCase):
             self.assertTrue(utils.check_password("ldap", self.password1, hp1, "utf8"))
             self.assertFalse(utils.check_password("ldap", self.password2, hp1, "utf8"))
 
-    @unittest.skipIf(sys.version_info >= (3,13), "crypt module removed from python 3.13")
+    @unittest.skipIf(sys.version_info >= (3, 13), "crypt module removed from python 3.13")
     def test_ldap_password_fail(self):
         """test the ldap auth method with malformed hash or bad schemes"""
         salt = b"UVVAQvrMyXMF3FF3"

--- a/cas_server/tests/test_utils.py
+++ b/cas_server/tests/test_utils.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2025 Valentin Samir
 """Tests module for utils"""
 import django
 from django.test import TestCase, RequestFactory

--- a/cas_server/tests/test_utils.py
+++ b/cas_server/tests/test_utils.py
@@ -15,7 +15,6 @@ from django.test import TestCase, RequestFactory
 from django.db import connection
 
 import sys
-import six
 import warnings
 import datetime
 import unittest
@@ -71,15 +70,12 @@ class CheckPasswordCase(TestCase):
         salts = ["$6$UVVAQvrMyXMF3FF3", "aa"]
         hashed_password1 = []
         for salt in salts:
-            if six.PY3:
-                hashed_password1.append(
-                    utils.crypt.crypt(
-                        self.password1.decode("utf8"),
-                        salt
-                    ).encode("utf8")
-                )
-            else:
-                hashed_password1.append(utils.crypt.crypt(self.password1, salt))
+            hashed_password1.append(
+                utils.crypt.crypt(
+                    self.password1.decode("utf8"),
+                    salt
+                ).encode("utf8")
+            )
 
         for hp1 in hashed_password1:
             self.assertTrue(utils.check_password("crypt", self.password1, hp1, "utf8"))
@@ -247,7 +243,7 @@ class UtilsTestCase(TestCase):
             )
         else:
             version = utils.last_version()
-            self.assertIsInstance(version, six.text_type)
+            self.assertIsInstance(version, str)
             self.assertEqual(len(version.split('.')), 3)
 
             # version is cached 24h so calling it a second time should return the save value

--- a/cas_server/tests/test_utils.py
+++ b/cas_server/tests/test_utils.py
@@ -14,9 +14,11 @@ import django
 from django.test import TestCase, RequestFactory
 from django.db import connection
 
+import sys
 import six
 import warnings
 import datetime
+import unittest
 
 from cas_server import utils
 
@@ -86,6 +88,7 @@ class CheckPasswordCase(TestCase):
         with self.assertRaises(ValueError):
             utils.check_password("crypt", self.password1, b"$truc$s$dsdsd", "utf8")
 
+    @unittest.skipIf(sys.version_info >= (3,13), "crypt module removed from python 3.13")
     def test_ldap_password_valid(self):
         """test the ldap auth method with all the schemes"""
         salt = b"UVVAQvrMyXMF3FF3"
@@ -113,6 +116,7 @@ class CheckPasswordCase(TestCase):
             self.assertTrue(utils.check_password("ldap", self.password1, hp1, "utf8"))
             self.assertFalse(utils.check_password("ldap", self.password2, hp1, "utf8"))
 
+    @unittest.skipIf(sys.version_info >= (3,13), "crypt module removed from python 3.13")
     def test_ldap_password_fail(self):
         """test the ldap auth method with malformed hash or bad schemes"""
         salt = b"UVVAQvrMyXMF3FF3"

--- a/cas_server/tests/test_view.py
+++ b/cas_server/tests/test_view.py
@@ -22,7 +22,6 @@ import random
 import json
 import mock
 from lxml import etree
-from six.moves import range
 
 from cas_server import models
 from cas_server import utils

--- a/cas_server/tests/test_view.py
+++ b/cas_server/tests/test_view.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2025 Valentin Samir
 """Tests module for views"""
 from cas_server.default_settings import settings
 

--- a/cas_server/tests/test_view.py
+++ b/cas_server/tests/test_view.py
@@ -20,7 +20,7 @@ from django.utils import timezone
 
 import random
 import json
-import mock
+from unittest import mock
 from lxml import etree
 
 from cas_server import models

--- a/cas_server/tests/utils.py
+++ b/cas_server/tests/utils.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2016 Valentin Samir
+# (c) 2016-2025 Valentin Samir
 """Some utils functions for tests"""
 from cas_server.default_settings import settings
 

--- a/cas_server/tests/utils.py
+++ b/cas_server/tests/utils.py
@@ -17,7 +17,6 @@ from django.test import Client
 from django.template import loader
 from django.utils import timezone
 
-import cgi
 import six
 from threading import Thread
 from lxml import etree
@@ -156,6 +155,40 @@ def get_proxy_ticket(service):
     return ticket
 
 
+def cgi_parse_header(line):
+    """Parse a Content-type like header.
+
+    Return the main content-type and a dictionary of options.
+
+    """
+
+    def _parseparam(s):
+        while s[:1] == ';':
+            s = s[1:]
+            end = s.find(';')
+            while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+                end = s.find(';', end + 1)
+            if end < 0:
+                end = len(s)
+            f = s[:end]
+            yield f.strip()
+            s = s[end:]
+
+    parts = _parseparam(';' + line)
+    key = parts.__next__()
+    pdict = {}
+    for p in parts:
+        i = p.find('=')
+        if i >= 0:
+            name = p[:i].strip().lower()
+            value = p[i+1:].strip()
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+                value = value.replace('\\\\', '\\').replace('\\"', '"')
+            pdict[name] = value
+    return key, pdict
+
+
 class HttpParamsHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     """
         A simple http server that return 200 on GET or POST
@@ -174,9 +207,9 @@ class HttpParamsHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
     def do_POST(self):
         """Called on a POST request on the BaseHTTPServer"""
-        ctype, pdict = cgi.parse_header(self.headers.get('content-type'))
+        ctype, pdict = cgi_parse_header(self.headers.get('content-type'))
         if ctype == 'multipart/form-data':
-            postvars = cgi.parse_multipart(self.rfile, pdict)
+            raise NotImplementedError()
         elif ctype == 'application/x-www-form-urlencoded':
             length = int(self.headers.get('content-length'))
             postvars = parse_qs(self.rfile.read(length), keep_blank_values=1)

--- a/cas_server/tests/utils.py
+++ b/cas_server/tests/utils.py
@@ -17,11 +17,10 @@ from django.test import Client
 from django.template import loader
 from django.utils import timezone
 
-import six
 from threading import Thread
 from lxml import etree
-from six.moves import BaseHTTPServer
-from six.moves.urllib.parse import urlparse, parse_qsl, parse_qs
+import http.server as BaseHTTPServer
+from urllib.parse import urlparse, parse_qsl, parse_qs
 from datetime import timedelta
 
 from cas_server import models
@@ -42,7 +41,7 @@ else:
 
 def return_unicode(string, charset):
     """make `string` a unicode if `string` is a unicode or bytes encoded with `charset`"""
-    if not isinstance(string, six.text_type):
+    if not isinstance(string, str):
         return string.decode(charset)
     else:
         return string
@@ -53,7 +52,7 @@ def return_bytes(string, charset):
         make `string` a bytes encoded with `charset` if `string` is a unicode
         or bytes encoded with `charset`
     """
-    if isinstance(string, six.text_type):
+    if isinstance(string, str):
         return string.encode(charset)
     else:
         return string

--- a/cas_server/urls.py
+++ b/cas_server/urls.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2021 Valentin Samir
 """urls for the app"""
 
 try:

--- a/cas_server/utils.py
+++ b/cas_server/utils.py
@@ -31,7 +31,6 @@ import string
 import json
 import hashlib
 import base64
-import six
 import requests
 import time
 import logging
@@ -44,7 +43,7 @@ except ImportError:
 
 from importlib import import_module
 from datetime import datetime, timedelta, timezone as tz
-from six.moves.urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
+from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 
 from . import VERSION
 
@@ -57,7 +56,7 @@ def json_encode(obj):
     try:
         return json_encode.encoder.encode(obj)
     except AttributeError:
-        json_encode.encoder = DjangoJSONEncoder(default=six.text_type)
+        json_encode.encoder = DjangoJSONEncoder(default=str)
         return json_encode(obj)
 
 
@@ -96,7 +95,7 @@ def context(params):
                     # make box discardable by default
                     msg["discardable"] = msg.get("discardable", True)
                     msg_hash = (
-                        six.text_type(msg["message"]).encode("utf-8") +
+                        str(msg["message"]).encode("utf-8") +
                         msg["type"].encode("utf-8")
                     )
                     # hash depend of the rendering language
@@ -129,10 +128,10 @@ def import_attr(path):
         :return: The python object pointed by the dotted path or the python object unchanged
     """
     # if we got a str, decode it to unicode (normally it should only contain ascii)
-    if isinstance(path, six.binary_type):
+    if isinstance(path, bytes):
         path = path.decode("utf-8")
     # if path is not an unicode, return it unchanged (may be it is already the attribute to import)
-    if not isinstance(path, six.text_type):
+    if not isinstance(path, str):
         return path
     if u"." not in path:
         ValueError("%r should be of the form `module.attr` and we just got `attr`" % path)
@@ -265,12 +264,8 @@ def update_url(url, params):
         else:
             return data
 
-    if six.PY3:
-        url = to_unicode(url)
-        params = {to_unicode(key): to_unicode(value) for (key, value) in params.items()}
-    else:
-        url = to_bytes(url)
-        params = {to_bytes(key): to_bytes(value) for (key, value) in params.items()}
+    url = to_unicode(url)
+    params = {to_unicode(key): to_unicode(value) for (key, value) in params.items()}
 
     url_parts = list(urlparse(url))
     query = dict(parse_qsl(url_parts[4], keep_blank_values=True))
@@ -575,14 +570,12 @@ class LdapHashUserPassword(object):
         except KeyError:
             if crypt is None:
                 raise cls.BadScheme("Crypt is not available on the system")
-            if six.PY3:
-                password = password.decode(charset)
-                salt = salt.decode(charset)
+            password = password.decode(charset)
+            salt = salt.decode(charset)
             if not crypt_salt_is_valid(salt):
                 raise cls.BadSalt("System crypt implementation do not support the salt %r" % salt)
             hashed_password = crypt.crypt(password, salt)
-            if six.PY3:
-                hashed_password = hashed_password.encode(charset)
+            hashed_password = hashed_password.encode(charset)
             return scheme + hashed_password
 
     @classmethod
@@ -647,9 +640,9 @@ def check_password(method, password, hashed_password, charset):
             ``False`` otherwise
         :rtype: bool
     """
-    if not isinstance(password, six.binary_type):
+    if not isinstance(password, bytes):
         password = password.encode(charset)
-    if not isinstance(hashed_password, six.binary_type):
+    if not isinstance(hashed_password, bytes):
         hashed_password = hashed_password.encode(charset)
     if method == "plain":
         return password == hashed_password
@@ -662,10 +655,9 @@ def check_password(method, password, hashed_password, charset):
             salt = hashed_password[:9]
         else:
             salt = hashed_password[:2]
-        if six.PY3:
-            password = password.decode(charset)
-            salt = salt.decode(charset)
-            hashed_password = hashed_password.decode(charset)
+        password = password.decode(charset)
+        salt = salt.decode(charset)
+        hashed_password = hashed_password.decode(charset)
         if not crypt_salt_is_valid(salt):
             raise ValueError("System crypt implementation do not support the salt %r" % salt)
         crypted_password = crypt.crypt(password, salt)

--- a/cas_server/utils.py
+++ b/cas_server/utils.py
@@ -43,7 +43,7 @@ except ImportError:
     crypt = None
 
 from importlib import import_module
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as tz
 from six.moves.urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 
 from . import VERSION
@@ -209,7 +209,7 @@ def set_cookie(response, key, value, max_age):
         :param int max_age: the maximum validity age of the cookie
     """
     expires = datetime.strftime(
-        datetime.utcnow() + timedelta(seconds=max_age),
+        datetime.now(tz.utc) + timedelta(seconds=max_age),
         "%a, %d-%b-%Y %H:%M:%S GMT"
     )
     response.set_cookie(

--- a/cas_server/utils.py
+++ b/cas_server/utils.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2025 Valentin Samir
 """Some util function for the app"""
 from .default_settings import settings
 

--- a/cas_server/views.py
+++ b/cas_server/views.py
@@ -8,7 +8,7 @@
 # along with this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# (c) 2015-2016 Valentin Samir
+# (c) 2015-2025 Valentin Samir
 """views for the app"""
 from .default_settings import settings, SessionStore
 

--- a/cas_server/views.py
+++ b/cas_server/views.py
@@ -655,7 +655,7 @@ class LoginView(View, LogoutMixin):
                 try:
                     server_creds = gssapi.Credentials(
                         usage='accept',
-                        name=gssapi.Name(settings.GSSAPI_AUTH_SERVICENAME)
+                        name=gssapi.Name(settings.CAS_AUTH_GSSAPI_SERVICENAME)
                     )
                 except gssapi.exceptions.GSSError as error:
                     logger.error("Fail to create GSSAPI credentials objects: %s" % (error,))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'django-cas-server'
-copyright = u'2016, Valentin Samir'
+copyright = u'2016-2025, Valentin Samir'
 author = u'Valentin Samir'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx
+sphinx_rtd_theme
+-r ../requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ setuptools>=5.5
 requests>=2.4
 requests_futures>=0.9.5
 lxml>=3.4
-six>=1.8
 tox>=1.8.1
 pytest>=7
 pytest-django>=2.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,3 @@ tox>=1.8.1
 pytest>=7
 pytest-django>=2.8.0
 pytest-cov>=2.2.1
-mock>=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django >= 1.11,<4.3
+Django >= 1.11,<5.3
 setuptools>=5.5
 requests>=2.4
 requests_futures>=0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ setuptools>=5.5
 requests>=2.4
 requests_futures>=0.9.5
 lxml>=3.4
-six>=1.8

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         keywords=['django', 'cas', 'cas3', 'server', 'sso', 'single sign-on', 'authentication', 'auth'],
         install_requires=[
             'Django >= 1.11,<4.3', 'requests >= 2.4', 'requests_futures >= 0.9.5',
-            'lxml >= 3.4', 'six >= 1'
+            'lxml >= 3.4'
         ],
         url="https://github.com/nitmir/django-cas-server",
         download_url="https://github.com/nitmir/django-cas-server/releases/latest",

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ if __name__ == '__main__':
         url="https://github.com/nitmir/django-cas-server",
         download_url="https://github.com/nitmir/django-cas-server/releases/latest",
         zip_safe=False,
-        setup_requires=['pytest-runner'],
+        setup_requires=[],
         tests_require=['pytest', 'pytest-django', 'pytest-pythonpath', 'pytest-warnings', 'mock>=1'],
     )

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ if __name__ == '__main__':
             'Framework :: Django :: 2.2',
             'Framework :: Django :: 3.2',
             'Framework :: Django :: 4.2',
+            'Framework :: Django :: 5.2',
             'Intended Audience :: Developers',
             'Intended Audience :: System Administrators',
             'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',

--- a/tox.ini
+++ b/tox.ini
@@ -217,7 +217,7 @@ deps =
 ################
 
 [testenv:py312-django42]
-basepython=python3.10
+basepython=python3.12
 deps =
     Django>=4.2,<4.3
     {[base]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,9 @@ envlist=
     check_rst,
     py3-django111,
     py3-django22,
-    py3-django31,
     py3-django32,
-    py3-django40,
-    py3-django41,
     py3-django42,
+    py3-django52,
 
 ##################
 # generic config #
@@ -114,34 +112,22 @@ deps =
     Django>=2.2,<2.3
     {[base]deps}
 
-[testenv:py3-django31]
-basepython=python3
-deps =
-    Django>=3.1,<3.2
-    {[base]deps}
-
 [testenv:py3-django32]
 basepython=python3
 deps =
     Django>=3.2,<3.3
     {[base]deps}
 
-[testenv:py3-django40]
-basepython=python3
-deps =
-    Django>=4.0,<4.1
-    {[base]deps}
-
-[testenv:py3-django41]
-basepython=python3
-deps =
-    Django>=4.1,<4.2
-    {[base]deps}
-
 [testenv:py3-django42]
 basepython=python3
 deps =
     Django>=4.2,<4.3
+    {[base]deps}
+
+[testenv:py3-django52]
+basepython=python3
+deps =
+    Django>=5.2,<5.3
     {[base]deps}
 
 #########################
@@ -226,24 +212,41 @@ deps =
     {[base]deps}
 
 
-#######################################
-# Django additional supported version #
-#######################################
+################
+# Ubuntu noble #
+################
 
-[testenv:py39-django42]
-basepython=python3.9
-deps =
-    Django>=4.2,<4.3
-    {[base]deps}
-
-[testenv:py310-django42]
+[testenv:py312-django42]
 basepython=python3.10
 deps =
     Django>=4.2,<4.3
     {[base]deps}
 
-[testenv:py311-django42]
+
+#######################################
+# Django additional supported version #
+#######################################
+
+[testenv:py310-django52]
+basepython=python3.10
+deps =
+    Django>=5.2,<5.3
+    {[base]deps}
+
+[testenv:py311-django52]
 basepython=python3.11
 deps =
-    Django>=4.2,<4.3
+    Django>=5.2,<5.3
+    {[base]deps}
+
+[testenv:py312-django52]
+basepython=python3.12
+deps =
+    Django>=5.2,<5.3
+    {[base]deps}
+
+[testenv:py313-django52]
+basepython=python3.13
+deps =
+    Django>=5.2,<5.3
     {[base]deps}


### PR DESCRIPTION
v3.0.0 - 2025-04-21
===================

Added
-----

* Support for Django 5.2
* Support for Kerberos/GSSAPI authentication

Changed
-------

* Allow more complex LDAP user queries
* Prefer local inventory for intersphinx
* Replace mock test module with the one from unittest

Removed
-------

* Drop support for Django 4.0 and 4.1 as it reached end of life.
* Removed six transitional dependency. This break for sure
  python 2.7 if it was still working
* Remove pytest-runner as it's deprecated

Deprecated
----------

* Using %s in your CAS_LDAP_USER_QUERY is deprecated.
  Please upgrade your config to use %(username)s instead

Fix
---

* datetime.datetime.utcnow() is deprecated and scheduled for removal.
  Use timezone-aware objects to represent datetimes in UTC:
  datetime.datetime.now(datetime.timezone.UTC).
* Skip tests using crypt module if module is not available
